### PR TITLE
Presto gateway logs

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -27,7 +27,7 @@ import org.apache.http.HttpStatus;
 public class ActiveClusterMonitor implements Managed {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final int BACKEND_CONNECT_TIMEOUT_SECONDS = 15;
-  private static final int MONITOR_TASK_DELAY_MIN = 1;
+  private static final int MONITOR_TASK_DELAY_SECS = 5;
 
   @Inject
   private List<PrestoClusterStatsObserver> clusterStatsObservers;
@@ -71,7 +71,7 @@ public class ActiveClusterMonitor implements Managed {
               log.error("Error performing backend monitor tasks", e);
             }
             try {
-              Thread.sleep(TimeUnit.MINUTES.toMillis(MONITOR_TASK_DELAY_MIN));
+              Thread.sleep(MONITOR_TASK_DELAY_SECS * 1000);
             } catch (Exception e) {
               log.error("Error with monitor task", e);
             }
@@ -112,6 +112,7 @@ public class ActiveClusterMonitor implements Managed {
           clusterStats.setBlockedQueryCount((int) result.get("blockedQueries"));
           clusterStats.setProxyTo(backend.getProxyTo());
           clusterStats.setRoutingGroup(backend.getRoutingGroup());
+          log.info("Host: {}, Cluster_stat: {}", System.getProperty("HOSTNAME"), clusterStats);
           break;
         } else {
           log.warn("Received non 200 response, response code: {}", responseCode);


### PR DESCRIPTION
```
INFO  [2020-07-31 16:31:19,617] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=12, queuedQueryCount=122, blockedQueryCount=0, numWorkerNodes=5, healthy=true, clusterId=main, proxyTo=http://presto.prod1.6si.com:12000, routingGroup=pipeline)
INFO  [2020-07-31 16:31:19,622] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount=0, numWorkerNodes=2, healthy=true, clusterId=adhoc, proxyTo=http://presto-adhoc.prod1.6si.com:12000, routingGroup=adhoc)
INFO  [2020-07-31 16:31:19,622] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount=0, numWorkerNodes=4, healthy=true, clusterId=aa2, proxyTo=http://presto-aa2.prod1.6si.com:12000, routingGroup=aa-write)
INFO  [2020-07-31 16:31:19,625] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount=0, numWorkerNodes=6, healthy=true, clusterId=aa1, proxyTo=http://presto-aa1.prod1.6si.com:12000, routingGroup=aa-read)
INFO  [2020-07-31 16:31:19,627] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount=0, numWorkerNodes=3, healthy=true, clusterId=pipeline1, proxyTo=http://presto-pipeline1.prod1.6si.com:12000, routingGroup=pipeline)
INFO  [2020-07-31 16:31:19,627] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount=0, numWorkerNodes=1, healthy=true, clusterId=meta1, proxyTo=http://presto-meta1.prod1.6si.com:12000, routingGroup=meta)
INFO  [2020-07-31 16:31:19,678] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount=0, numWorkerNodes=1, healthy=true, clusterId=meta2, proxyTo=http://presto-meta2.prod1.6si.com:12000, routingGroup=meta)
WARN  [2020-07-31 16:31:19,737] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Received non 200 response, response code: 404
INFO  [2020-07-31 16:31:19,817] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount=0, numWorkerNodes=3, healthy=true, clusterId=pipeline4, proxyTo=http://presto-pipeline4.prod1.6si.com:12000, routingGroup=pipeline)
WARN  [2020-07-31 16:31:24,673] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Received non 200 response, response code: 404
INFO  [2020-07-31 16:31:24,751] com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor: Host: null, Cluster_stat: ClusterStats(runningQueryCount=0, queuedQueryCount=0, blockedQueryCount
```