### PR TITLE
INFRA-1740 history size

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -31,7 +31,7 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
     super(configuration, environment);
     connectionManager = new JdbcConnectionManager(configuration.getDataStore());
     gatewayBackendManager = new HaGatewayManager(connectionManager);
-    queryHistoryManager = new HaQueryHistoryManager(connectionManager);
+    queryHistoryManager = new HaQueryHistoryManager(configuration, connectionManager);
     routingManager =
         new PrestoQueueLengthRoutingTable(gatewayBackendManager,
                 (HaQueryHistoryManager) queryHistoryManager);

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaQueryHistoryManager.java
@@ -1,5 +1,6 @@
 package com.lyft.data.gateway.ha.router;
 
+import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import com.lyft.data.gateway.ha.persistence.dao.QueryHistory;
 import java.util.List;
@@ -8,9 +9,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class HaQueryHistoryManager implements QueryHistoryManager {
   private JdbcConnectionManager connectionManager;
+  private HaGatewayConfiguration configuration;
 
-  public HaQueryHistoryManager(JdbcConnectionManager connectionManager) {
+  public HaQueryHistoryManager(HaGatewayConfiguration conf,
+                               JdbcConnectionManager connectionManager) {
     this.connectionManager = connectionManager;
+    this.configuration = conf;
   }
 
   @Override
@@ -26,9 +30,10 @@ public class HaQueryHistoryManager implements QueryHistoryManager {
 
   @Override
   public List<QueryDetail> fetchQueryHistory() {
+    int limit = this.configuration.getRequestRouter().getHistorySize();
     try {
       connectionManager.open();
-      return QueryHistory.upcast(QueryHistory.findAll().limit(2000).orderBy("created desc"));
+      return QueryHistory.upcast(QueryHistory.findAll().limit(limit).orderBy("created desc"));
     } finally {
       connectionManager.close();
     }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -4,7 +4,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.lyft.data.gateway.ha.HaGatewayTestUtils;
 import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
+import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+import com.lyft.data.gateway.ha.config.RequestRouterConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import java.io.File;
 import java.util.HashMap;
@@ -37,8 +39,11 @@ public class TestPrestoQueueLengthRoutingTable {
         new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
     DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
     JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
+    HaGatewayConfiguration gatewayConf = new HaGatewayConfiguration();
+    RequestRouterConfiguration routerConf = new RequestRouterConfiguration();
+    gatewayConf.setRequestRouter(routerConf);
     backendManager = new HaGatewayManager(connectionManager);
-    historyManager = new HaQueryHistoryManager(connectionManager) {
+    historyManager = new HaQueryHistoryManager(gatewayConf, connectionManager) {
     };
     routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager);
 

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestQueryHistoryManager.java
@@ -2,6 +2,8 @@ package com.lyft.data.gateway.ha.router;
 
 import com.lyft.data.gateway.ha.HaGatewayTestUtils;
 import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
+import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
+import com.lyft.data.gateway.ha.config.RequestRouterConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 
 import java.io.File;
@@ -25,7 +27,11 @@ public class TestQueryHistoryManager {
     String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
     DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
     JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
-    queryHistoryManager = new HaQueryHistoryManager(connectionManager) {};
+    HaGatewayConfiguration gatewayConf = new HaGatewayConfiguration();
+    RequestRouterConfiguration routerConf = new RequestRouterConfiguration();
+    routerConf.setHistorySize(5);
+    gatewayConf.setRequestRouter(routerConf);
+    queryHistoryManager = new HaQueryHistoryManager(gatewayConf, connectionManager) {};
   }
 
   public void testSubmitAndFetchQueryHistory() {
@@ -36,13 +42,13 @@ public class TestQueryHistoryManager {
     queryDetail.setSource("sqlWorkbench");
     queryDetail.setUser("test@ea.com");
     queryDetail.setQueryText("select 1");
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < 10; i++) {
       queryDetail.setQueryId(String.valueOf(System.currentTimeMillis()));
       queryDetail.setCaptureTime(System.currentTimeMillis());
       queryHistoryManager.submitQueryDetail(queryDetail);
     }
     queryDetails = queryHistoryManager.fetchQueryHistory();
-    Assert.assertEquals(queryDetails.size(), 2);
+    Assert.assertEquals(queryDetails.size(), 5);
     Assert.assertTrue(queryDetails.get(0).getCaptureTime() > queryDetails.get(1).getCaptureTime());
   }
 }


### PR DESCRIPTION
Changes HaQueryHistoryManager to pull the history size limit from HaGatewayConfiguration instead of using a hardcoded value. Tested to make sure that it correctly reads the yaml config file and sets the value from there as well (set the value to 10 in this case):
![Screenshot from 2021-04-09 16-43-58](https://user-images.githubusercontent.com/70175606/114250768-a1c04600-9953-11eb-9eb7-37b07c5d7b52.png)
