### PR TITLE
[INFRA-2635] Increase Jetty client Header buffer size

### DIFF
--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServletImpl.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServletImpl.java
@@ -35,6 +35,10 @@ public class ProxyServletImpl extends ProxyServlet.Transparent {
     HttpClient httpClient = new HttpClient(sslFactory);
     httpClient.setMaxConnectionsPerDestination(10000);
     httpClient.setConnectTimeout(TimeUnit.SECONDS.toMillis(60));
+    // Increase Header buffer size
+    // For prepared statements, Presto sends the prepared query in the header
+    // So, the default buffer size of 4kb is insufficient for large queries
+    httpClient.setRequestBufferSize(65536); //64kb
     return httpClient;
   }
 


### PR DESCRIPTION
https://6sense.atlassian.net/browse/INFRA-2635

Why?
----
* For Prepared statements, Presto sends the prepared query in the Header
* So, for large queries if the allowed header size is not large enough, we are going to run into issues.

How?
----
* Increase the Header Buffer size in the Jetty client

Testing Evidence
----------------
<details>
<summary><b>Sample Query</b></summary>
<p>

```sql
PREPARE stmt1 FROM SELECT
RESULT_DATA.createyear as createyear, 
RESULT_DATA.createmonth as createmonth, 
RESULT_DATA.category_id as category_id, 
RESULT_DATA.stage_status as stage_status, 
RESULT_DATA.channelid as channelid, 
RESULT_DATA.leadsource as leadsource, 
RESULT_DATA.primarycampaignname as primarycampaignname, 
RESULT_DATA.primarycampaigntype as primarycampaigntype, 
SUM(RESULT_DATA.current_amount) as amount, 
COUNT(*) as count 
FROM 
(SELECT 
CASE 
  WHEN DAY(stage_first_created_at) >= 1 THEN YEAR(stage_first_created_at) 
  WHEN MONTH(stage_first_created_at) = 1 THEN YEAR(DATE_ADD('year', -1, stage_first_created_at)) 
  ELSE YEAR(stage_first_created_at) 
END AS createyear, 
CASE 
  WHEN DAY(stage_first_created_at) >= 1 THEN MONTH(stage_first_created_at) 
  WHEN MONTH(stage_first_created_at) = 1 THEN 12 
  ELSE MONTH( DATE_ADD('month', -1, stage_first_created_at)) 
END AS createmonth, 
'summary' AS category_id, 
stage_status, COALESCE(channel_id, 'UNKNOWN') as channelid, 
COALESCE(lead_source, 'UNKNOWN') as leadsource, 
COALESCE(primary_campaign_name, 'UNKNOWN') as primarycampaignname, 
COALESCE(primary_campaign_type, 'UNKNOWN') as primarycampaigntype, 
current_amount AS current_amount 
FROM 
  (SELECT DISTINCT OPSTH_3.opportunity_id, OPSTH_3.stage_first_created_at AS stage_first_created_at, 
         OPSTH_3.lead_source AS lead_source, current_amount AS current_amount, 
         OPSTH_3.category_id AS category_id, 
         OPSTH_3.channel_id AS channel_id, 
         OPSTH_3.primary_campaign_name AS primary_campaign_name, 
         OPSTH_3.primary_campaign_type AS primary_campaign_type, 
         OPSTH_MIN.stage_status AS stage_status 
   FROM 
     fortella_opportunity_stage_history_inferred AS OPSTH_3 
   INNER JOIN 
     (SELECT OPSTH_2.opportunity_id, OPSTH_EXCL_PRE.stage_status as stage_status, MIN(stage_first_created_at) AS stage_first_created_at 
      FROM 
        fortella_opportunity_stage_history_inferred as OPSTH_2 
     INNER JOIN 
       (SELECT OPSTH_1.opportunity_id, OPSTH_1.stage_status
        FROM 
          fortella_opportunity_stage_history_inferred as OPSTH_1 
        INNER JOIN 
          (SELECT opportunity_id, 
                  GREATEST(MAX(IF(stage_last_created_at < DATE('2021-11-09'), stage_last_created_at, stage_first_created_at)),
                    MAX(stage_first_created_at)
                  ) AS stage_max_created_at 
           FROM 
             fortella_opportunity_stage_history_inferred AS OPSTH 
           WHERE stage_last_created_at >= DATE('2021-2-1') 
                 AND (stage_last_created_at < DATE('2021-11-09') OR stage_first_created_at < DATE('2021-11-09')) 
                 AND opportunity_created_at < DATE('2022-2-1') 
              AND cast(json_extract(custom_fields, '$.is_pipeline') as int) = 1 
           GROUP BY opportunity_id) AS OPSTH_MAX 
        ON OPSTH_1.opportunity_id = OPSTH_MAX.opportunity_id 
           AND (OPSTH_1.stage_last_created_at = OPSTH_MAX.stage_max_created_at OR OPSTH_1.stage_first_created_at = OPSTH_MAX.stage_max_created_at) 
        WHERE 
          OPSTH_1.stage_name IN ('Stage 0 - Calendared Meeting','Stage 1 - Understand Pain & Priority','Stage 2 - Agreement on Evaluation Plan','Stage 3 - Solution Validation','Stage 4 - Executive Confirmation','Stage 5 - Contracting','Stage 6 - Closed Won','Stage 1 - Onboarding & Adoption','Stage 2 - Use Case + Value Confirmation','Stage 3 - Executive Confirmation','Stage 4 - Contracting & Redlining','Stage 5 - Closed Won','Stage 1 - Referral','Stage 2 - Closed Won','Dead - Lost')) AS OPSTH_EXCL_PRE 
     ON OPSTH_2.opportunity_id = OPSTH_EXCL_PRE.opportunity_id 
                and OPSTH_2.ts_end_time > 2707200000     WHERE OPSTH_2.stage_name IN ('Stage 0 - Calendared Meeting','Stage 1 - Understand Pain & Priority','Stage 2 - Agreement on Evaluation Plan','Stage 3 - Solution Validation','Stage 4 - Executive Confirmation','Stage 5 - Contracting','Stage 6 - Closed Won','Stage 1 - Onboarding & Adoption','Stage 2 - Use Case + Value Confirmation','Stage 3 - Executive Confirmation','Stage 4 - Contracting & Redlining','Stage 5 - Closed Won','Stage 1 - Referral','Stage 2 - Closed Won')
     GROUP BY OPSTH_2.opportunity_id, OPSTH_EXCL_PRE.stage_status) AS OPSTH_MIN 
   ON OPSTH_3.opportunity_id = OPSTH_MIN.opportunity_id 
      AND OPSTH_3.stage_first_created_at = OPSTH_MIN.stage_first_created_at 
   WHERE OPSTH_3.stage_first_created_at >= DATE('2021-2-1')  
         AND OPSTH_3.stage_first_created_at < DATE('2021-11-09') AND OPSTH_3.stage_first_created_at < DATE('2022-2-1')) AS OPSTH_4) AS RESULT_DATA
GROUP BY createyear, createmonth, category_id, stage_status, channelid, leadsource, primarycampaignname, primarycampaigntype;


EXECUTE stmt1;
```
</p>
</details>

* The execute stmt fails without the fix. While it works correctly after the fix

Deployment Steps
----------------
* Merge this PR
* Open a PR in ntropy repo with the current HEAD commit updated in `WORKSPACE` file
* Merge the ntropy PR and deploy presto-gateway service

Deployment Verification
-----------------------
* Verify that the sample query given above runs correctly in production
