### PR TITLE
[INFRA-2756] Jetty server and client - Increase request buffer size to 1MB

### DIFF
--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServer.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServer.java
@@ -43,7 +43,7 @@ public class ProxyServer implements Closeable {
     // Increase Header buffer size
     // For prepared statements, Presto sends the prepared query in the header
     // So, the default buffer size of 8kb is insufficient for large queries
-    httpConfig.setRequestHeaderSize(65536); //64kb
+    httpConfig.setRequestHeaderSize(1048576); //1MB
 
     if (config.isSsl()) {
       String keystorePath = config.getKeystorePath();

--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServletImpl.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServletImpl.java
@@ -38,7 +38,7 @@ public class ProxyServletImpl extends ProxyServlet.Transparent {
     // Increase Header buffer size
     // For prepared statements, Presto sends the prepared query in the header
     // So, the default buffer size of 4kb is insufficient for large queries
-    httpClient.setRequestBufferSize(65536); //64kb
+    httpClient.setRequestBufferSize(1048576); //1MB
     return httpClient;
   }
 


### PR DESCRIPTION
https://6sense.atlassian.net/browse/INFRA-2756

Why?
----
* For Execute statement, Presto sends the prepared query from the previous Prepare stmt, in the Header
* So, for large queries if the allowed header size is not large enough, we are going to run into issues.

How?
----
* Increase the Header Buffer size in the Jetty server (default is 8KB, increase to 1MB as default Presto query size limit is 1MB)
* We had earlier increased the client buffer size from 4KB to 64KB. Increase this also to 1MB.

Testing Evidence
----------------
<details>
<summary><b>Sample Query</b></summary>
<p>

```sql
prepare stmt1 from SELECT 
RESULT_DATA.create_year as create_year, 
RESULT_DATA.create_month as create_month, 
RESULT_DATA.current_stage as current_stage, 
RESULT_DATA.conversion_days_range as conversion_days_range, 
'AaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as field1,
COUNT(RESULT_DATA.opportunity_id) AS total_count, 
IF(SUM(RESULT_DATA.opp_amount) IS NULL, 0.0, SUM(RESULT_DATA.opp_amount)) AS total_amount, 
SUM(RESULT_DATA.days) as total_days, 
RESULT_DATA.channel_id as channel_id 
FROM 
 (SELECT 
  CASE 
    WHEN stage_first_created_at IS NULL THEN 0 
    WHEN DAY(stage_first_created_at) >= 1 THEN  YEAR(stage_first_created_at) 
    WHEN Month(stage_first_created_at) = 1 THEN YEAR(DATE_ADD('YEAR', -1, stage_first_created_at) ) 
    ELSE Year(stage_first_created_at) 
  END AS create_year, 
  CASE 
    WHEN stage_first_created_at IS NULL THEN 0 
    WHEN DAY(stage_first_created_at) >= 1 THEN  MONTH(stage_first_created_at) 
    WHEN MONTH(stage_first_created_at) = 1 THEN 12 
     ELSE MONTH(DATE_ADD('MONTH', -1, stage_first_created_at)) 
  END AS create_month, 
  CASE 
    WHEN current_status = 'Closed Won' THEN 0 
    WHEN current_status = 'Closed Lost' THEN 1 
    ELSE 2 
  END AS current_stage, 
  CASE 
    WHEN IF(current_status = 'Open', 99999,date_diff('day', DATE(stage_first_created_at), sanitized_close_date)) < 31 THEN 0
    WHEN IF(current_status = 'Open', 99999, date_diff('day', DATE(stage_first_created_at), sanitized_close_date)) >= 31 AND IF(current_status = 'Open', 99999,date_diff('day', DATE(stage_first_created_at), sanitized_close_date)) < 91 THEN 1
    WHEN IF(current_status = 'Open', 99999, date_diff('day', DATE(stage_first_created_at), sanitized_close_date)) >= 91 AND IF(current_status = 'Open', 99999,date_diff('day', DATE(stage_first_created_at), sanitized_close_date)) < 181 THEN 2
    WHEN IF(current_status = 'Open', 99999, date_diff('day', DATE(stage_first_created_at), sanitized_close_date)) >= 181 THEN 3
  END AS conversion_days_range, 
   opportunity_id AS opportunity_id, 
   opp_amount AS opp_amount, 
   IF(current_status = 'Open', 
          99999, 
          IF(date_diff('day', DATE(stage_first_created_at), sanitized_close_date) < 0, 
             0, 
date_diff('day', DATE(stage_first_created_at), sanitized_close_date)
          ) 
       ) 
   AS days, 
  CASE 
    WHEN channel_id IS NULL THEN 'UNKNOWN' 
    ELSE channel_id 
  END AS channel_id 
 FROM 
   (SELECT DISTINCT 
      OPSTH_3.opportunity_id AS opportunity_id, OPSTH_3.current_status as current_status, OPSTH_3.current_close_date as closed_date,
      IF(OPSTH_3.current_close_date IS NULL, OPSTH_MIN.latest_stage_created_at, OPSTH_3.current_close_date) as sanitized_close_date, 
      OPSTH_3.stage_first_created_at AS stage_first_created_at, current_amount AS opp_amount, 
	   OPSTH_3.channel_id AS channel_id 
     FROM fortella_opportunity_stage_history_inferred AS OPSTH_3 
    INNER JOIN 
      (SELECT OPSTH_2.opportunity_id, OPSTH_EXCL_PRE.stage_last_created_at as latest_stage_created_at, min(stage_first_created_at) AS stage_first_created_at 
       FROM fortella_opportunity_stage_history_inferred AS OPSTH_2 
       INNER JOIN 
         (SELECT OPSTH_1.opportunity_id, OPSTH_MAX.stage_last_created_at 
          FROM fortella_opportunity_stage_history_inferred AS OPSTH_1 
          INNER JOIN 
            (SELECT opportunity_id, max(stage_last_created_at) AS stage_last_created_at 
             FROM fortella_opportunity_stage_history_inferred AS OPSTH 
INNER JOIN 
 segment AS SEG 
 ON OPSTH.master_id = SEG.mid 
 AND SEG.segment_id = 144567 AND SEG.dt = '2021-11-29' AND OPSTH.product_name = '6sense' AND OPSTH.ts_end_time > 2707200000
             WHERE stage_last_created_at >= DATE('2020-02-01')
                   AND opportunity_created_at <  DATE('2022-02-01')
AND cast(json_extract(custom_fields, '$.is_pipeline') as int) = 1
             GROUP BY opportunity_id) AS OPSTH_MAX 
          ON OPSTH_1.opportunity_id = OPSTH_MAX.opportunity_id 
             AND OPSTH_1.stage_last_created_at = OPSTH_MAX.stage_last_created_at 
          WHERE 
            OPSTH_1.stage_name IN ('Stage 2 - Agreement on Evaluation Plan','Stage 3 - Solution Validation','Stage 4 - Executive Confirmation','Stage 5 - Contracting','Stage 6 - Closed Won','Stage 1 - Onboarding & Adoption','Stage 2 - Use Case + Value Confirmation','Stage 3 - Executive Confirmation','Stage 4 - Contracting & Redlining','Stage 5 - Closed Won','Stage 1 - Referral','Stage 2 - Closed Won','Dead - Lost')) AS OPSTH_EXCL_PRE 
       ON OPSTH_2.opportunity_id = OPSTH_EXCL_PRE.opportunity_id 
 		AND OPSTH_2.ts_end_time > 2707200000       WHERE OPSTH_2.stage_name IN ('Stage 2 - Agreement on Evaluation Plan','Stage 3 - Solution Validation','Stage 4 - Executive Confirmation','Stage 5 - Contracting','Stage 6 - Closed Won','Stage 1 - Onboarding & Adoption','Stage 2 - Use Case + Value Confirmation','Stage 3 - Executive Confirmation','Stage 4 - Contracting & Redlining','Stage 5 - Closed Won','Stage 1 - Referral','Stage 2 - Closed Won') 
       GROUP BY OPSTH_2.opportunity_id, OPSTH_EXCL_PRE.stage_last_created_at) AS OPSTH_MIN 
    ON OPSTH_3.opportunity_id = OPSTH_MIN.opportunity_id 
       AND OPSTH_3.stage_first_created_at = OPSTH_MIN.stage_first_created_at 
       WHERE OPSTH_3.stage_first_created_at >= DATE('2020-02-01')
             AND OPSTH_3.stage_first_created_at <  DATE('2022-02-01')
			  AND OPSTH_3.current_status IN ('Closed Won','Closed Lost') 
 AND (OPSTH_3.channel_id IN ('b227aa3c-e278-4f53-99d5-06d47fabf135','5e8d6bbd-406c-4610-bb50-615d526422c5','47df8f0e-e442-4695-ab5b-89dc22f3bb4b','9ea51b0b-cb69-474c-8ce1-aa8aaf2ecbd6') or OPSTH_3.channel_id is NULL) 
              AND OPSTH_3.category_id IN ('4709732e-5322-11ec-a47e-0e8f9403daa9','d88bbe3c-ad47-4aa0-9191-7b8f95491ece','c5cb5023-96b3-4ce1-9a55-150ec8c9503e','69371b04-7629-4375-b3b8-38682c1b0021')) AS OPSTH_4) AS RESULT_DATA
 GROUP BY create_year, create_month, conversion_days_range, current_stage, channel_id;

EXECUTE stmt1;
```
</p>
</details>

* The execute stmt fails without the fix. While it works correctly after the fix. Tested both locally and after deploying to `-karthik` env

Deployment Steps
----------------
* Merge this PR
* Open a PR in ntropy repo with the current HEAD commit updated in `WORKSPACE` file
* Merge the ntropy PR and deploy presto-gateway service

Deployment Verification
-----------------------
* Verify that the sample query given above runs correctly in production
* Keep monitoring presto-gateway resource usage as we have increased the buffer sizes. The memory requirement for the Presto Gateway service might have to be increased.
