### PR TITLE
INFRA-3677 Fix api stats path for presto cluster

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -87,7 +87,7 @@ public class ActiveClusterMonitor implements Managed {
     String[] possiblePaths = new String[] {UI_API_STATS_PATH, "/v1/cluster"};
     String dynpath = ""; //Path Based on Presto and Trino cluster
     for (String path : possiblePaths) {
-      if backend.getProxyTo().contains("trino") or backend.getProxyTo().contains("dashboard") {
+      if ( backend.getProxyTo().contains("trino") || backend.getProxyTo().contains("dashboard") ) {
         dynpath = UI_API_STATS_PATH;
       } else {
         dynpath = "/v1/cluster";

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -87,7 +87,7 @@ public class ActiveClusterMonitor implements Managed {
     String[] possiblePaths = new String[] {UI_API_STATS_PATH, "/v1/cluster"};
     String dynpath = ""; //Path Based on Presto and Trino cluster
     for (String path : possiblePaths) {
-      if ( backend.getProxyTo().contains("trino") || backend.getProxyTo().contains("dashboard") ) {
+      if (backend.getProxyTo().contains("trino") || backend.getProxyTo().contains("dashboard")) {
         dynpath = UI_API_STATS_PATH;
       } else {
         dynpath = "/v1/cluster";

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -85,8 +85,14 @@ public class ActiveClusterMonitor implements Managed {
     // The V1_NODE_PATH is used in 331 while V1_CLUSTER_PATH is used in 318
     // TODO: Remove V1_CLUSTER_PATH once we're upgraded all clusters.
     String[] possiblePaths = new String[] {UI_API_STATS_PATH, "/v1/cluster"};
+    String dynpath = ""; //Path Based on Presto and Trino cluster
     for (String path : possiblePaths) {
-      String target = backend.getProxyTo() + path;
+      if backend.getProxyTo().contains("trino") or backend.getProxyTo().contains("dashboard") {
+        dynpath = UI_API_STATS_PATH;
+      } else {
+        dynpath = "/v1/cluster";
+      }
+      String target = backend.getProxyTo() + dynpath;
       HttpURLConnection conn = null;
       try {
         URL url = new URL(target);


### PR DESCRIPTION
Why-

Presto-gateway is checking `ui/api/stats` clustermonitor APIs into presto cluster which is invalid for presto and valid for trino cluster.  It is causing ~100/mins error logs loggged into datadog. 

https://app.datadoghq.com/apm/traces?query=env%3Adev%20status%3Aerror%20service%3Apresto-gateway&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=false&messageDisplay=inline&sort=desc&spanID=5630181826926102127&timeHint=1652896218272&trace=68487338741376369715630181826926102127&traceID=6848733874137636971&start=1652895979301&end=1652896879301&paused=false

https://app.datadoghq.com/apm/traces?query=env%3Aprod1%20status%3Aerror%20service%3Apresto-gateway&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=false&messageDisplay=inline&sort=desc&start=1652896027515&end=1652896927515&paused=false

How- 
Added corresponding dynamic path based on presto/trino cluster type into cluster health monitor of presto-gateway to mitigate this issue. 

Testing- 
** Created presto-gateway image - 242358675102.dkr.ecr.us-east-1.amazonaws.com/sixsense/presto-gateway:env-dheeraj.20220518165335-1aab68d530f9 using PR commits and deployed into presto-gateway dev environment.  Error went away from presto-gateway dev endpoint. 
 https://presto-gateway.dev.6si.com/viewgateway
 
 https://app.datadoghq.com/apm/traces?query=env%3Adev%20status%3Aerror%20service%3Apresto-gateway&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=false&messageDisplay=inline&sort=desc&spanID=5630181826926102127&timeHint=1652896218272&trace=68487338741376369715630181826926102127&traceID=6848733874137636971&start=1652896220335&end=1652897120335&paused=false
 
 Deployment Steps- 
 * After PR merge, raise another PR into ntropy with updated commit of presto-gateway 
 * After merging Both PRs, new develop image should deploy to presto-gateway and check if errors is going away from presto-gateway prod1 endpoints. 
 
 @davidecerri @faryeyay @hashken Please review and approve the PR. 
 