### PR TITLE
INFRA-3963 Fix Incorrect Presto Cluster Redirect Link

### DIFF
--- a/gateway-ha/src/main/resources/template/gateway-view.ftl
+++ b/gateway-ha/src/main/resources/template/gateway-view.ftl
@@ -58,7 +58,7 @@
         <#list backendConfigurations as bc>
             <tr>
                 <td>  ${bc.name}</td>
-                <td><a href="${bc.proxyTo}/ui" target="_blank">${bc.proxyTo}</a></td>
+                <td><a href="${bc.proxyTo}/ui/" target="_blank">${bc.proxyTo}</a></td>
                 <td> ${bc.routingGroup}</td>
             </tr>
         </#list>


### PR DESCRIPTION
- [x] Include relevant Jira ticket ID(s) in the PR title

## Why
 - When clicking on a presto backend in presto-gateway, it would redirect you to an incorrect page
 - This PR fixes the url that the presto backend link redirects to
## How
 - Corrects URL on .ftl template for the backends page
## Testing evidence
 - Redirect url is now ".../ui/" instead of ".../ui"
## Deployment Steps
 - N/A
## Deployment Verification
 - Check if presto backends redirect to a complete page