### PR TITLE
INFRA-4000 Add UI Features for Routing Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Edit the [config file](/gateway-ha/gateway-ha-config.yml) and update the mysql d
 cd gateway-ha/target/
 java -jar gateway-ha-{{VERSION}}-jar-with-dependencies.jar server ../gateway-ha-config.yml
 ```
-Now you can access load balanced presto at localhost:8080 port. We will refer to this as `prestogateway.lyft.com`
+Now you can access load balanced presto at localhost:8080 port. We will refer to this as `presto-gateway.prod.6si.com`
  
 ## Gateway API
 
@@ -100,11 +100,11 @@ curl -X POST http://localhost:8080/gateway/backend/deactivate/presto2
 
 ### Query History UI - check query plans etc.
 PrestoGateway records history of recent queries and displays links to check query details page in respective presto cluster.  
-![prestogateway.lyft.com](/docs/assets/prestogateway_query_history.png) 
+![presto-gateway.prod.6si.com](/docs/assets/prestogateway_query_history.png) 
 
 ### Gateway Admin UI - add and modify backend information
 The Gateway admin page is used to configure the gateway to multiple backends. Existing backend information can also be modified using the same.
-![prestogateway.lyft.com/entity](/docs/assets/prestogateway_ha_admin.png) 
+![presto-gateway.prod.6si.com/entity](/docs/assets/prestogateway_ha_admin.png) 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now open mysql console and install the presto-gateway tables:
 mysql -uroot -proot123 -h127.0.0.1 -Dprestogateway
 
 ```
-Once logged in to mysql console, please run [gateway-ha-persistence.sql](/gateway-ha/src/main/resources/gateway-ha-persistence.sql) to populate the tables.
+Once logged in to mysql console, please run [gateway-ha-persistence.sql](/gateway-ha/src/migrations/gateway-ha.sql) to populate the tables.
 
 
 Step 2: Edit the configuration `gateway-ha-config.yml`

--- a/gateway-ha/README.md
+++ b/gateway-ha/README.md
@@ -240,3 +240,21 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
     }
 ]
 ```
+
+### Pause a routing group
+
+`curl -X POST prestogateway.lyft.com/gateway/backend/pauseRoutingGroup/adhoc`
+
+Verify this by calling get active backends and checking that all in the routing group are absent
+```
+curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+```
+
+### Resume a routing group
+
+`curl -X POST prestogateway.lyft.com/gateway/backend/pauseRoutingGroup/adhoc`
+
+Verify this by calling get active backends and checking that all in the routing group are present
+```
+curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+```

--- a/gateway-ha/README.md
+++ b/gateway-ha/README.md
@@ -252,7 +252,7 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
 
 ### Resume a routing group
 
-`curl -X POST prestogateway.lyft.com/gateway/backend/pauseRoutingGroup/adhoc`
+`curl -X POST prestogateway.lyft.com/gateway/backend/resumeRoutingGroup/adhoc`
 
 Verify this by calling get active backends and checking that all in the routing group are present
 ```

--- a/gateway-ha/README.md
+++ b/gateway-ha/README.md
@@ -50,7 +50,7 @@ server /path/to/gateway-ha/src/test/resources/config-template.yml
 ``` 
 
 ## Gateway HA API
-# Note: A backend must have a valid routing group in order to be added successfully 
+#### Note: A backend must have a valid routing group in order to be added successfully 
 
 ### Get all backends behind the gateway
 

--- a/gateway-ha/README.md
+++ b/gateway-ha/README.md
@@ -50,6 +50,7 @@ server /path/to/gateway-ha/src/test/resources/config-template.yml
 ``` 
 
 ## Gateway HA API
+# Note: A backend must have a valid routing group in order to be added successfully 
 
 ### Get all backends behind the gateway
 
@@ -76,16 +77,10 @@ server /path/to/gateway-ha/src/test/resources/config-template.yml
     }
 ]
 ```
-### Delete a backend from the gateway
+### Get all active backend behind the Gateway
 
+`curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool`
 ```
-curl -v -H "Content-Type: application/json" -d '{"name": "presto3"}' http://prestogateway.lyft.com/gateway/backend/modify/delete
-```
-
-Verify this by calling get active backends
-```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
-
 [
     {
         "active": true,
@@ -98,9 +93,14 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
         "name": "presto2",
         "proxyTo": "http://presto2.lyft.com",
         "routingGroup": "adhoc"
+    },
+    {
+        "active": true,
+        "name": "presto3",
+        "proxyTo": "http://presto3.lyft.com",
+        "routingGroup": "adhoc"
     }
 ]
-
 ```
 ### Add a backend to the gateway
 
@@ -164,10 +164,16 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
     }
 ]
 ```
-### Get all active backend behind the Gateway
+### Delete a backend from the gateway
 
-`curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool`
 ```
+curl -v -H "Content-Type: application/json" -d '{"name": "presto3"}' http://prestogateway.lyft.com/gateway/backend/modify/delete
+```
+
+Verify this by calling get active backends
+```
+curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+
 [
     {
         "active": true,
@@ -180,14 +186,9 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
         "name": "presto2",
         "proxyTo": "http://presto2.lyft.com",
         "routingGroup": "adhoc"
-    },
-    {
-        "active": true,
-        "name": "presto3",
-        "proxyTo": "http://presto3.lyft.com",
-        "routingGroup": "adhoc"
     }
 ]
+
 ```
 ### Deactivate a backend 
 
@@ -241,20 +242,22 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
 ]
 ```
 
+### Add a routing group
+
+`curl -X POST prestogateway.lyft.com/gateway/routingGroup -d '{"name": "[name of routing group]", "active": [true/false]}'`
+
+### Update a routing group
+
+`curl -X PUT prestogateway.lyft.com/gateway/routingGroup -d '{"name": "[name of routing group]", "active": [true/false]}'`
+
+### Delete a routing group
+
+`curl -X DELETE prestogateway.lyft.com/gateway/routingGroup -d '[name of routing group]'`
+
 ### Pause a routing group
 
-`curl -X POST prestogateway.lyft.com/gateway/backend/pauseRoutingGroup/adhoc`
-
-Verify this by calling get active backends and checking that all in the routing group are absent
-```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
-```
+`curl -X POST prestogateway.lyft.com/gateway/routingGroup/pauseRoutingGroup/[name of routing group]`
 
 ### Resume a routing group
 
-`curl -X POST prestogateway.lyft.com/gateway/backend/resumeRoutingGroup/adhoc`
-
-Verify this by calling get active backends and checking that all in the routing group are present
-```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
-```
+`curl -X POST prestogateway.lyft.com/gateway/routingGroup/resumeRoutingGroup/[name of routing group]`

--- a/gateway-ha/README.md
+++ b/gateway-ha/README.md
@@ -248,11 +248,11 @@ curl -X GET presto-gateway.prod.6si.com/gateway/backend/active | python -m json.
 
 ### Update a routing group
 
-`curl -X PUT presto-gateway.prod.6si.com/gateway/routingGroup -d '{"name": "[name of routing group]", "active": [true/false]}'`
+`curl -X PUT presto-gateway.prod.6si.com/gateway/routingGroup/[name of routing group] -d '{"active": [true/false]}'`
 
 ### Delete a routing group
 
-`curl -X DELETE presto-gateway.prod.6si.com/gateway/routingGroup -d '[name of routing group]'`
+`curl -X DELETE presto-gateway.prod.6si.com/gateway/routingGroup/[name of routing group]`
 
 ### Pause a routing group
 

--- a/gateway-ha/README.md
+++ b/gateway-ha/README.md
@@ -12,15 +12,15 @@ Edit the [config file](../gateway/src/main/resources/config.yml.template) and up
 cd gateway-ha/target/
 java -jar gateway=ha-{{VERSION}}-jar-with-dependencies.jar server ../config.yml.template
 ```
-Now you can access load balanced presto at localhost:8080 port. We will refer to this as `prestogateway.lyft.com`
+Now you can access load balanced presto at localhost:8080 port. We will refer to this as `presto-gateway.prod.6si.com`
  
 ### Query History UI - check query plans etc.
 PrestoGateway records history of recent queries and displays links to check query details page in respective presto cluster.  
-![prestogateway.lyft.com](../docs/assets/prestogateway_query_history.png) 
+![presto-gateway.prod.6si.com](../docs/assets/prestogateway_query_history.png) 
 
 ### Gateway Admin UI - add and modify backend information
 The Gateway admin page is used to configure the gateway to multiple backends. Existing backend information can also be modified using the same.
-![prestogateway.lyft.com/admin](../docs/assets/prestogateway_ha_admin.png) 
+![presto-gateway.prod.6si.com/entity](../docs/assets/prestogateway_ha_admin.png) 
 
 How to setup a dev environment
 ----------------------------
@@ -54,7 +54,7 @@ server /path/to/gateway-ha/src/test/resources/config-template.yml
 
 ### Get all backends behind the gateway
 
-`curl -X GET prestogateway.lyft.com/gateway/backend/all | python -m json.tool`
+`curl -X GET presto-gateway.prod.6si.com/gateway/backend/all | python -m json.tool`
 ```
 [
     {
@@ -79,7 +79,7 @@ server /path/to/gateway-ha/src/test/resources/config-template.yml
 ```
 ### Get all active backend behind the Gateway
 
-`curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool`
+`curl -X GET presto-gateway.prod.6si.com/gateway/backend/active | python -m json.tool`
 ```
 [
     {
@@ -105,12 +105,12 @@ server /path/to/gateway-ha/src/test/resources/config-template.yml
 ### Add a backend to the gateway
 
 ```
-curl -v -H "Content-Type: application/json" -d '{"name": "presto3","proxyTo": "http://presto3.lyft.com","active": false,"routingGroup": "adhoc"}' http://prestogateway.lyft.com/gateway/backend/modify/add
+curl -v -H "Content-Type: application/json" -d '{"name": "presto3","proxyTo": "http://presto3.lyft.com","active": false,"routingGroup": "adhoc"}' http://presto-gateway.prod.6si.com/gateway/backend/modify/add
 ```
 
 Verify this by calling get active backends
 ```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+curl -X GET presto-gateway.prod.6si.com/gateway/backend/active | python -m json.tool
 
 [
     {
@@ -136,12 +136,12 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
 ### Update backend information 
 
 ```
-curl -v -H "Content-Type: application/json" -d '{"name": "presto3","localPort": 8084,"proxyTo": "http://presto3.lyft.com","includeInRouter": true,"active": false,"routingGroup": "adhoc"}' http://prestogateway.lyft.com/gateway/backend/modify/add
+curl -v -H "Content-Type: application/json" -d '{"name": "presto3","localPort": 8084,"proxyTo": "http://presto3.lyft.com","includeInRouter": true,"active": false,"routingGroup": "adhoc"}' http://presto-gateway.prod.6si.com/gateway/backend/modify/add
 ```
 
 Verify if the port number is updated by calling get active backends
 ```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+curl -X GET presto-gateway.prod.6si.com/gateway/backend/active | python -m json.tool
 
 [
     {
@@ -167,12 +167,12 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
 ### Delete a backend from the gateway
 
 ```
-curl -v -H "Content-Type: application/json" -d '{"name": "presto3"}' http://prestogateway.lyft.com/gateway/backend/modify/delete
+curl -v -H "Content-Type: application/json" -d '{"name": "presto3"}' http://presto-gateway.prod.6si.com/gateway/backend/modify/delete
 ```
 
 Verify this by calling get active backends
 ```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+curl -X GET presto-gateway.prod.6si.com/gateway/backend/active | python -m json.tool
 
 [
     {
@@ -192,11 +192,11 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
 ```
 ### Deactivate a backend 
 
-`curl -X POST prestogateway.lyft.com/gateway/backend/deactivate/presto2`
+`curl -X POST presto-gateway.prod.6si.com/gateway/backend/deactivate/presto2`
 
 Verify this by calling get active backends
 ```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+curl -X GET presto-gateway.prod.6si.com/gateway/backend/active | python -m json.tool
 [
     {
         "active": true,
@@ -214,11 +214,11 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
 ```
 ### Activate a backend 
 
-`curl -X POST prestogateway.lyft.com/gateway/backend/activate/presto2`
+`curl -X POST presto-gateway.prod.6si.com/gateway/backend/activate/presto2`
 
 Verify this by calling get active backends
 ```
-curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
+curl -X GET presto-gateway.prod.6si.com/gateway/backend/active | python -m json.tool
 
 [
     {
@@ -244,20 +244,20 @@ curl -X GET prestogateway.lyft.com/gateway/backend/active | python -m json.tool
 
 ### Add a routing group
 
-`curl -X POST prestogateway.lyft.com/gateway/routingGroup -d '{"name": "[name of routing group]", "active": [true/false]}'`
+`curl -X POST presto-gateway.prod.6si.com/gateway/routingGroup -d '{"name": "[name of routing group]", "active": [true/false]}'`
 
 ### Update a routing group
 
-`curl -X PUT prestogateway.lyft.com/gateway/routingGroup -d '{"name": "[name of routing group]", "active": [true/false]}'`
+`curl -X PUT presto-gateway.prod.6si.com/gateway/routingGroup -d '{"name": "[name of routing group]", "active": [true/false]}'`
 
 ### Delete a routing group
 
-`curl -X DELETE prestogateway.lyft.com/gateway/routingGroup -d '[name of routing group]'`
+`curl -X DELETE presto-gateway.prod.6si.com/gateway/routingGroup -d '[name of routing group]'`
 
 ### Pause a routing group
 
-`curl -X POST prestogateway.lyft.com/gateway/routingGroup/pauseRoutingGroup/[name of routing group]`
+`curl -X POST presto-gateway.prod.6si.com/gateway/routingGroup/pauseRoutingGroup/[name of routing group]`
 
 ### Resume a routing group
 
-`curl -X POST prestogateway.lyft.com/gateway/routingGroup/resumeRoutingGroup/[name of routing group]`
+`curl -X POST presto-gateway.prod.6si.com/gateway/routingGroup/resumeRoutingGroup/[name of routing group]`

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingGroupConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingGroupConfiguration.java
@@ -1,0 +1,36 @@
+package com.lyft.data.gateway.ha.config;
+
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * This class stores information about a routing group.
+ */
+@Data
+@ToString
+public class RoutingGroupConfiguration {
+  private String name;
+  private boolean active;
+  private int groupSize;
+  private int activeClusters;
+
+  public RoutingGroupConfiguration(String name) {
+    this.name = name;
+    active = false;
+    groupSize = 0;
+    activeClusters = 0;
+  }
+
+  /**
+   * Registers a backend associated with the routing group.
+   * @param backend Backend to register
+   */
+  public void registerBackend(ProxyBackendConfiguration backend) {
+    if (backend.isActive()) {
+      active = true;
+      activeClusters++;
+    }
+
+    groupSize++;
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingGroupConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingGroupConfiguration.java
@@ -1,5 +1,7 @@
 package com.lyft.data.gateway.ha.config;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Data;
 import lombok.ToString;
 
@@ -11,14 +13,28 @@ import lombok.ToString;
 public class RoutingGroupConfiguration {
   private String name;
   private boolean active;
-  private int groupSize;
+  private int numberOfClusters;
   private int activeClusters;
 
-  public RoutingGroupConfiguration(String name) {
+  /**
+   * Constructor specifying name and active state of routing group.
+   * @param name Name of routing group
+   * @param active Activate state of routing group
+   */
+  public RoutingGroupConfiguration(@JsonProperty("name") String name, 
+      @JsonProperty("active") boolean active) {
     this.name = name;
-    active = false;
-    groupSize = 0;
+    this.active = active;
+    numberOfClusters = 0;
     activeClusters = 0;
+  }
+
+  /**
+   * Constructor specifying name of routing group.
+   * @param name Name of routing group
+   */
+  public RoutingGroupConfiguration(String name) {
+    this(name, true);
   }
 
   /**
@@ -27,10 +43,9 @@ public class RoutingGroupConfiguration {
    */
   public void registerBackend(ProxyBackendConfiguration backend) {
     if (backend.isActive()) {
-      active = true;
       activeClusters++;
     }
 
-    groupSize++;
+    numberOfClusters++;
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/RoutingGroups.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/RoutingGroups.java
@@ -1,0 +1,72 @@
+package com.lyft.data.gateway.ha.persistence.dao;
+
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.IdName;
+import org.javalite.activejdbc.annotations.Table;
+
+@Slf4j
+@Table("routing_groups")
+@IdName("name")
+@Cached
+public class RoutingGroups extends Model {
+  private static final String name = "name";
+  private static final String active = "active";
+
+  /**
+   * Upcasts list of routing groups returned from a query and
+   * returns a list of routing group configurations contianing
+   * the same information.
+   * @param routingGroupList List of routing groups from query
+   * @return List of routing group confugurations
+   */
+  public static List<RoutingGroupConfiguration> upcast(List<RoutingGroups> routingGroupList) {
+    List<RoutingGroupConfiguration> routingGroupConfigurations = new ArrayList<>();
+    for (RoutingGroups model : routingGroupList) {
+      routingGroupConfigurations.add(new RoutingGroupConfiguration(model.getString(name),
+                                                                   model.getBoolean(active)));
+    }
+
+    return routingGroupConfigurations;
+  }
+
+  /**
+   * Creates a routing group in the table.
+   * @param group Information of routing group
+   */
+  public static void create(RoutingGroupConfiguration group) {
+    RoutingGroups.create(name, group.getName(), active, group.isActive()).insert();
+  }
+
+  /**
+   * Updates information about a routing group in the table.
+   * @param model Model representing table entry of group
+   * @param group Information of routing group
+   */
+  public static void update(RoutingGroups model, RoutingGroupConfiguration group) {
+    model.set(name, group.getName(), active, group.isActive()).saveIt();
+  }
+
+  /**
+   * Deletes a routing group from the table.
+   * @param group Information of routing group
+   */
+  public static void delete(RoutingGroupConfiguration group) {
+    RoutingGroups.create(name, group.getName(), active, group.isActive()).delete();
+  }
+
+  /**
+   * Deletes a routing group from the table by name.
+   * @param name Name of routing group to delete.
+   */
+  public static void delete(String name) {
+    RoutingGroups.delete("name = ?", name);
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
@@ -2,6 +2,7 @@ package com.lyft.data.gateway.ha.resource;
 
 import com.google.inject.Inject;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
+import com.lyft.data.gateway.ha.router.RoutingGroupsManager;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -18,8 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 @Path("/gateway")
 @Produces(MediaType.APPLICATION_JSON)
 public class GatewayResource {
-
   @Inject private GatewayBackendManager gatewayBackendManager;
+  @Inject private RoutingGroupsManager routingGroupsManager;
 
   @GET
   public Response ok(@Context Request request) {
@@ -77,43 +78,12 @@ public class GatewayResource {
   }
 
   /**
-   * Pause a specific routing group.
-   * @param name Name of routing group
+   * Method to throw an error response.
+   * @param e Error called
+   * @return Response containing error
    */
-  @POST
-  @Path("/backend/pauseRoutingGroup/{name}")
-  public Response pauseRoutingGroup(@PathParam("name") String name) {
-    try {
-      this.gatewayBackendManager.pauseRoutingGroup(name);
-    } catch (Exception e) {
-      log.error(e.getMessage(), e);
-      return throwError(e);
-    }
-
-    return Response.ok().build();
-  }
-
-  /**
-   * Resume a specific routing group.
-   * @name Name of routing group
-   */
-  @POST
-  @Path("/backend/resumeRoutingGroup/{name}")
-  public Response resumeRoutingGroup(@PathParam("name") String name) {
-    try {
-      this.gatewayBackendManager.resumeRoutingGroup(name);
-    } catch (Exception e) {
-      log.error(e.getMessage(), e);
-      return throwError(e);
-    }
-
-    return Response.ok().build();
-  }
-
-  private Response throwError(Exception e) {
-    return Response.status(Response.Status.NOT_FOUND)
-        .entity(e.getMessage())
-        .type("text/plain")
+  public static Response throwError(Exception e) {
+    return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
         .build();
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
@@ -26,18 +26,28 @@ public class GatewayResource {
     return Response.ok("ok").build();
   }
 
+  /**
+   * Gets all backends.
+   */
   @GET
   @Path("/backend/all")
   public Response getAllBackends() {
     return Response.ok(this.gatewayBackendManager.getAllBackends()).build();
   }
 
+  /**
+   * Gets all active backends.
+   */
   @GET
   @Path("/backend/active")
   public Response getActiveBackends() {
     return Response.ok(gatewayBackendManager.getAllActiveBackends()).build();
   }
 
+  /**
+   * Deactivate a specific cluster.
+   * @name Name of cluster
+   */
   @POST
   @Path("/backend/deactivate/{name}")
   public Response deactivateBackend(@PathParam("name") String name) {
@@ -50,6 +60,10 @@ public class GatewayResource {
     return Response.ok().build();
   }
 
+  /**
+   * Activate a specific cluster.
+   * @name Name of cluster
+   */
   @POST
   @Path("/backend/activate/{name}")
   public Response activateBackend(@PathParam("name") String name) {
@@ -59,6 +73,40 @@ public class GatewayResource {
       log.error(e.getMessage(), e);
       return throwError(e);
     }
+    return Response.ok().build();
+  }
+
+  /**
+   * Pause a specific routing group.
+   * @param name Name of routing group
+   */
+  @POST
+  @Path("/backend/pauseRoutingGroup/{name}")
+  public Response pauseRoutingGroup(@PathParam("name") String name) {
+    try {
+      this.gatewayBackendManager.pauseRoutingGroup(name);
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
+    return Response.ok().build();
+  }
+
+  /**
+   * Resume a specific routing group.
+   * @name Name of routing group
+   */
+  @POST
+  @Path("/backend/resumeRoutingGroup/{name}")
+  public Response resumeRoutingGroup(@PathParam("name") String name) {
+    try {
+      this.gatewayBackendManager.resumeRoutingGroup(name);
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
     return Response.ok().build();
   }
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
@@ -98,12 +98,12 @@ public class GatewayResource {
   }
 
   /**
-   * Method to throw an 415 error response.
+   * Method to throw an 500 error response.
    * @param e Error called
    * @return Response containing error
    */
   public static Response throwError(Exception e) {
-    return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
         .build();
   }
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayResource.java
@@ -1,5 +1,6 @@
 package com.lyft.data.gateway.ha.resource;
 
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
 import com.lyft.data.gateway.ha.router.RoutingGroupsManager;
@@ -52,6 +53,10 @@ public class GatewayResource {
   @POST
   @Path("/backend/deactivate/{name}")
   public Response deactivateBackend(@PathParam("name") String name) {
+    if (isValidName(name) != null) {
+      return isValidName(name);
+    }
+
     try {
       this.gatewayBackendManager.deactivateBackend(name);
     } catch (Exception e) {
@@ -68,22 +73,47 @@ public class GatewayResource {
   @POST
   @Path("/backend/activate/{name}")
   public Response activateBackend(@PathParam("name") String name) {
+    if (isValidName(name) != null) {
+      return isValidName(name);
+    }
+
     try {
       this.gatewayBackendManager.activateBackend(name);
     } catch (Exception e) {
       log.error(e.getMessage(), e);
       return throwError(e);
     }
+
     return Response.ok().build();
   }
 
   /**
-   * Method to throw an error response.
+   * Checks if the name in the path is valid and returns a 404
+   * error if its not.
+   * @param name Name supplied through URI
+   * @return 404 response if invalid and null otherwise
+   */
+  public static Response isValidName(String name) {
+    return Strings.isNullOrEmpty(name) ? throw404Error() : null;
+  }
+
+  /**
+   * Method to throw an 415 error response.
    * @param e Error called
    * @return Response containing error
    */
   public static Response throwError(Exception e) {
     return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
+        .build();
+  }
+
+  /**
+   * Method to throw 404 error on invalid path.
+   * @param e Error called
+   * @return Response containing error
+   */
+  public static Response throw404Error() {
+    return Response.status(Response.Status.NOT_FOUND)
         .build();
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayViewResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayViewResource.java
@@ -2,6 +2,7 @@ package com.lyft.data.gateway.ha.resource;
 
 import com.google.inject.Inject;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
 import com.lyft.data.gateway.ha.router.QueryHistoryManager;
 import io.dropwizard.views.View;
@@ -17,44 +18,77 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+/**
+ * This class provides the HTML produced when somebody visites the
+ * web page and also creates multiple API endpoints for
+ * communicaiton.
+ */
 @Path("/")
 public class GatewayViewResource {
   private static final long START_TIME = System.currentTimeMillis();
   @Inject private GatewayBackendManager gatewayBackendManager;
   @Inject private QueryHistoryManager queryHistoryManager;
 
+  /**
+   * This function creates and returns a view that represents the homepage
+   * of the website, which is the query history page. The associated ftl template
+   * lives at "/template/query-history-view.ftl".
+   * 
+   * @return A view associated with the homepage (query details and history)
+   */
   @GET
   @Produces(MediaType.TEXT_HTML)
   public GatewayView getQueryDetailsView() {
     GatewayView queryHistoryView = new GatewayView("/template/query-history-view.ftl");
-    // Get All active backends
-    queryHistoryView.setBackendConfigurations(
-        gatewayBackendManager.getAllBackends().stream()
-            .filter(ProxyBackendConfiguration::isActive)
-            .collect(Collectors.toList()));
-
-    queryHistoryView.setQueryHistory(queryHistoryManager.fetchQueryHistory());
-    queryHistoryView.setQueryDistribution(getQueryHistoryDistribution());
+    fillGatewayViewWithInfo(queryHistoryView);
+    
     return queryHistoryView;
   }
 
+  /**
+   * This function creates and returns a view that represents the view gateway
+   * page on the website. The associated ftl template lives at
+   * "/template/gateway-view.ftl".
+   * 
+   * <p>This page is accessible at "/viewgateway".
+   * @return A view for the viewGateway page
+   */
   @GET
   @Produces(MediaType.TEXT_HTML)
   @Path("viewgateway")
   public GatewayView getGatewayView() {
     GatewayView gatewayView = new GatewayView("/template/gateway-view.ftl");
-    // Get All active backends
-    gatewayView.setBackendConfigurations(
-        gatewayBackendManager.getAllBackends().stream()
-            .filter(ProxyBackendConfiguration::isActive)
-            .collect(Collectors.toList()));
-
-    gatewayView.setQueryHistory(queryHistoryManager.fetchQueryHistory());
-    gatewayView.setQueryDistribution(getQueryHistoryDistribution());
+    fillGatewayViewWithInfo(gatewayView);
+    
     return gatewayView;
   }
 
+  /**
+   * This function creates and returns a view that represents the routing groups
+   * on the website. The associated ftl template with lives at
+   * "/template/routing-groupts-view.ftl".
+   * 
+   * <p>This information is accessible at "/routingGroups".
+   * @return A view for the routingGroups page
+   */
+  @GET
+  @Produces(MediaType.TEXT_HTML)
+  @Path("routingGroups")
+  public GatewayView getRoutingGroupView() {
+    GatewayView routingGroupsView = new GatewayView("/template/routing-groups-view.ftl");
+    fillGatewayViewWithInfo(routingGroupsView);
+
+    return routingGroupsView;
+  }
+
+  /**
+   * This function gets the query history.
+   * 
+   * <p>This information is accessible at "/api/queryHistory".
+   * @return A list of the query history
+   */
   @GET
   @Path("api/queryHistory")
   @Produces(MediaType.APPLICATION_JSON)
@@ -62,6 +96,12 @@ public class GatewayViewResource {
     return queryHistoryManager.fetchQueryHistory();
   }
 
+  /**
+   * This functions gets all active backends.
+   * 
+   * <p>This information is accessible at "/api/activeBackends".
+   * @return A list of all active backends
+   */
   @GET
   @Path("api/activeBackends")
   @Produces(MediaType.APPLICATION_JSON)
@@ -71,6 +111,27 @@ public class GatewayViewResource {
         .collect(Collectors.toList());
   }
 
+  /**
+   * This function gets all routing groups.
+   * 
+   * <p>This information is accessible at "/api/routingGroups".
+   * @return A list of routing groups
+   */
+  @GET
+  @Path("api/routingGroups")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<RoutingGroupConfiguration> getRoutingGroups() {
+    List<ProxyBackendConfiguration> backends = gatewayBackendManager.getAllBackends();
+    return gatewayBackendManager.getAllRoutingGroups(backends);
+  }
+
+  /**
+   * This function returns a mapping of each backend to the number
+   * of queries it has processed.
+   * 
+   * <p>This information is accessible at "/api/queryHistoryDistribution".
+   * @return A map containing backends and the number of queries it processed
+   */
   @GET
   @Path("api/queryHistoryDistribution")
   @Produces(MediaType.APPLICATION_JSON)
@@ -92,18 +153,36 @@ public class GatewayViewResource {
               if (backend == null) {
                 backend = q.getBackendUrl();
               }
-              if (!clusterToQueryCount.containsKey(backend)) {
-                clusterToQueryCount.put(backend, 0);
-              }
+
+              clusterToQueryCount.putIfAbsent(backend, 0);
               clusterToQueryCount.put(backend, clusterToQueryCount.get(backend) + 1);
             });
+            
     return clusterToQueryCount;
   }
 
+  /**
+   * This function fills a gateway view with relavent information.
+   * @param view View to be filled in
+   */
+  private void fillGatewayViewWithInfo(GatewayView view) {
+    List<ProxyBackendConfiguration> backends = gatewayBackendManager.getAllBackends();
+    view.setBackendConfigurations(backends);
+    view.setRoutingGroupConfigurations(gatewayBackendManager.getAllRoutingGroups(backends));
+
+    view.setQueryHistory(queryHistoryManager.fetchQueryHistory());
+    view.setQueryDistribution(getQueryHistoryDistribution());
+  }
+
+  /**
+   * This class holds the data that is passed into the ftl templates.
+   */
   @Data
+  @EqualsAndHashCode(callSuper = false)
   public static class GatewayView extends View {
     private final long gatewayStartTime = START_TIME;
     private List<ProxyBackendConfiguration> backendConfigurations;
+    private List<RoutingGroupConfiguration> routingGroupConfigurations;
     private List<QueryHistoryManager.QueryDetail> queryHistory;
     private Map<String, Integer> queryDistribution;
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayViewResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/GatewayViewResource.java
@@ -5,6 +5,8 @@ import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
 import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
 import com.lyft.data.gateway.ha.router.QueryHistoryManager;
+import com.lyft.data.gateway.ha.router.RoutingGroupsManager;
+
 import io.dropwizard.views.View;
 
 import java.nio.charset.Charset;
@@ -30,6 +32,7 @@ public class GatewayViewResource {
   private static final long START_TIME = System.currentTimeMillis();
   @Inject private GatewayBackendManager gatewayBackendManager;
   @Inject private QueryHistoryManager queryHistoryManager;
+  @Inject private RoutingGroupsManager routingGroupsManager;
 
   /**
    * This function creates and returns a view that represents the homepage
@@ -122,7 +125,7 @@ public class GatewayViewResource {
   @Produces(MediaType.APPLICATION_JSON)
   public List<RoutingGroupConfiguration> getRoutingGroups() {
     List<ProxyBackendConfiguration> backends = gatewayBackendManager.getAllBackends();
-    return gatewayBackendManager.getAllRoutingGroups(backends);
+    return routingGroupsManager.getAllRoutingGroups(backends);
   }
 
   /**
@@ -168,7 +171,8 @@ public class GatewayViewResource {
   private void fillGatewayViewWithInfo(GatewayView view) {
     List<ProxyBackendConfiguration> backends = gatewayBackendManager.getAllBackends();
     view.setBackendConfigurations(backends);
-    view.setRoutingGroupConfigurations(gatewayBackendManager.getAllRoutingGroups(backends));
+    view.setRoutingGroupConfigurations(routingGroupsManager
+        .getAllRoutingGroups(backends));
 
     view.setQueryHistory(queryHistoryManager.fetchQueryHistory());
     view.setQueryDistribution(getQueryHistoryDistribution());

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/HaGatewayResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/HaGatewayResource.java
@@ -1,9 +1,13 @@
 package com.lyft.data.gateway.ha.resource;
 
+import static com.lyft.data.gateway.ha.resource.GatewayResource.throwError;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
-import com.lyft.data.gateway.ha.router.HaGatewayManager;
+
+import java.io.IOException;
 
 import javax.ws.rs.POST;
 
@@ -14,31 +18,70 @@ import javax.ws.rs.core.Response;
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * This class creates endpoints that allow for the addition,
+ * modification, and deletion of endpoints.
+ */
 @Slf4j
 @Path("gateway/backend/modify")
 @Produces(MediaType.APPLICATION_JSON)
 public class HaGatewayResource {
-
   @Inject private GatewayBackendManager haGatewayManager;
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+  /**
+   * Endpoint to add a backend.
+   * @param jsonPayload Data contained in json payload
+   * @return Response containing status of operation
+   */
   @Path("/add")
   @POST
-  public Response addBackend(ProxyBackendConfiguration backend) {
-    ProxyBackendConfiguration updatedBackend = haGatewayManager.addBackend(backend);
-    return Response.ok(updatedBackend).build();
+  public Response addBackend(String jsonPayload) {
+    ProxyBackendConfiguration addedBackend;
+
+    try {
+      ProxyBackendConfiguration backend = 
+          OBJECT_MAPPER.readValue(jsonPayload, ProxyBackendConfiguration.class);
+      addedBackend = haGatewayManager.addBackend(backend);
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
+    return Response.ok(addedBackend).build();
   }
 
+  /**
+   * Endpoint to update a backend.
+   * @param jsonPayload Data contained in json payload
+   * @return Response containing status of operation
+   */
   @Path("/update")
   @POST
-  public Response updateBackend(ProxyBackendConfiguration backend) {
-    ProxyBackendConfiguration updatedBackend = haGatewayManager.updateBackend(backend);
+  public Response updateBackend(String jsonPayload) {
+    ProxyBackendConfiguration updatedBackend;
+
+    try {
+      ProxyBackendConfiguration backend = 
+          OBJECT_MAPPER.readValue(jsonPayload, ProxyBackendConfiguration.class);
+      updatedBackend = haGatewayManager.updateBackend(backend);
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+    
     return Response.ok(updatedBackend).build();
   }
 
+  /**
+   * Endpoint to delete a backend.
+   * @param jsonPayload Name of backend to be deleted
+   * @return Response containing status of operation
+   */
   @Path("/delete")
   @POST
   public Response removeBackend(String name) {
-    ((HaGatewayManager) haGatewayManager).deleteBackend(name);
+    haGatewayManager.deleteBackend(name);
     return Response.ok().build();
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/RoutingGroupResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/RoutingGroupResource.java
@@ -1,6 +1,7 @@
 package com.lyft.data.gateway.ha.resource;
 
 import static com.lyft.data.gateway.ha.resource.GatewayResource.throwError;
+import static com.lyft.data.gateway.ha.resource.GatewayResource.isValidName;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
@@ -51,10 +52,16 @@ public class RoutingGroupResource {
    * @return Response containing status of query
    */
   @PUT
-  public Response updateRoutingGroup(String jsonPayload) {
+  @Path("/{name}")
+  public Response updateRoutingGroup(@PathParam("name") String name, String jsonPayload) {
+    if (isValidName(name) != null) {
+      return isValidName(name);
+    }
+
     try {
       RoutingGroupConfiguration group = 
           OBJECT_MAPPER.readValue(jsonPayload, RoutingGroupConfiguration.class);
+      group.setName(name);
       routingGroupsManager.updateRoutingGroup(group);
     } catch (Exception e) {
       log.error(e.getMessage(), e);
@@ -70,7 +77,12 @@ public class RoutingGroupResource {
    * @return Response containing status of query
    */
   @DELETE
-  public Response deleteRoutingGroup(String name) {
+  @Path("/{name}")
+  public Response deleteRoutingGroup(@PathParam("name") String name) {
+    if (isValidName(name) != null) {
+      return isValidName(name);
+    }
+
     try {
       routingGroupsManager.deleteRoutingGroups(name);
     } catch (Exception e) {
@@ -88,6 +100,10 @@ public class RoutingGroupResource {
   @POST
   @Path("/pauseRoutingGroup/{name}")
   public Response pauseRoutingGroup(@PathParam("name") String name) {
+    if (isValidName(name) != null) {
+      return isValidName(name);
+    }
+
     try {
       routingGroupsManager.pauseRoutingGroup(name);
     } catch (Exception e) {
@@ -105,6 +121,10 @@ public class RoutingGroupResource {
   @POST
   @Path("/resumeRoutingGroup/{name}")
   public Response resumeRoutingGroup(@PathParam("name") String name) {
+    if (isValidName(name) != null) {
+      return isValidName(name);
+    }
+    
     try {
       routingGroupsManager.resumeRoutingGroup(name);
     } catch (Exception e) {

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/RoutingGroupResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/RoutingGroupResource.java
@@ -1,0 +1,117 @@
+package com.lyft.data.gateway.ha.resource;
+
+import static com.lyft.data.gateway.ha.resource.GatewayResource.throwError;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
+import com.lyft.data.gateway.ha.router.RoutingGroupsManager;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This class contains endpoints for interacting with routing groups,
+ * specifically creating, updating, and pausing them.
+ */
+@Slf4j
+@Path("gateway/routingGroups")
+public class RoutingGroupResource {
+  @Inject private RoutingGroupsManager routingGroupsManager;
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /**
+   * Endpoint to add a new routing group.
+   * @param jsonPayload Data in JSON payload
+   * @return Response containing status of query
+   */
+  @POST
+  public Response addRoutingGroup(String jsonPayload) {
+    try {
+      RoutingGroupConfiguration group = 
+          OBJECT_MAPPER.readValue(jsonPayload, RoutingGroupConfiguration.class);
+      routingGroupsManager.addRoutingGroup(group);
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
+    return Response.ok().build();
+  }
+
+  /**
+   * Endpoint to update a routing group.
+   * @param jsonPayload Data in JSON payload
+   * @return Response containing status of query
+   */
+  @PUT
+  public Response updateRoutingGroup(String jsonPayload) {
+    try {
+      RoutingGroupConfiguration group = 
+          OBJECT_MAPPER.readValue(jsonPayload, RoutingGroupConfiguration.class);
+      routingGroupsManager.updateRoutingGroup(group);
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
+    return Response.ok().build();
+  }
+
+  /**
+   * Endpoint to delete a routing group.
+   * @param name Name of routing group
+   * @return Response containing status of query
+   */
+  @DELETE
+  public Response deleteRoutingGroup(String name) {
+    try {
+      routingGroupsManager.deleteRoutingGroups(name);
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
+    return Response.ok().build();
+  }
+
+  /**
+   * Endpoint to pause a specific routing group.
+   * @param name Name of routing group
+   */
+  @POST
+  @Path("/pauseRoutingGroup/{name}")
+  public Response pauseRoutingGroup(@PathParam("name") String name) {
+    try {
+      routingGroupsManager.pauseRoutingGroup(name);
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
+    return Response.ok().build();
+  }
+
+  /**
+   * Endpoint to resume a specific routing group.
+   * @name Name of routing group
+   */
+  @POST
+  @Path("/resumeRoutingGroup/{name}")
+  public Response resumeRoutingGroup(@PathParam("name") String name) {
+    try {
+      routingGroupsManager.resumeRoutingGroup(name);
+    } catch (Exception e) {
+      log.error(e.getMessage(), e);
+      return throwError(e);
+    }
+
+    return Response.ok().build();
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/RoutingGroupResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/RoutingGroupResource.java
@@ -1,7 +1,7 @@
 package com.lyft.data.gateway.ha.resource;
 
-import static com.lyft.data.gateway.ha.resource.GatewayResource.throwError;
 import static com.lyft.data.gateway.ha.resource.GatewayResource.isValidName;
+import static com.lyft.data.gateway.ha.resource.GatewayResource.throwError;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/GatewayBackendManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/GatewayBackendManager.java
@@ -20,4 +20,8 @@ public interface GatewayBackendManager {
   void deactivateBackend(String backendName);
 
   void activateBackend(String backendName);
+
+  void pauseRoutingGroup(String routingGroup);
+
+  void resumeRoutingGroup(String routingGroup);
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/GatewayBackendManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/GatewayBackendManager.java
@@ -1,7 +1,6 @@
 package com.lyft.data.gateway.ha.router;
 
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
-import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 
 import java.util.List;
 
@@ -14,8 +13,6 @@ public interface GatewayBackendManager {
 
   List<ProxyBackendConfiguration> getActiveBackends(String routingGroup);
 
-  List<RoutingGroupConfiguration> getAllRoutingGroups(List<ProxyBackendConfiguration> backends);
-
   ProxyBackendConfiguration addBackend(ProxyBackendConfiguration backend);
 
   ProxyBackendConfiguration updateBackend(ProxyBackendConfiguration backend);
@@ -25,8 +22,4 @@ public interface GatewayBackendManager {
   void deactivateBackend(String backendName);
 
   void activateBackend(String backendName);
-
-  void pauseRoutingGroup(String routingGroup);
-
-  void resumeRoutingGroup(String routingGroup);
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/GatewayBackendManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/GatewayBackendManager.java
@@ -1,6 +1,7 @@
 package com.lyft.data.gateway.ha.router;
 
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 
 import java.util.List;
 
@@ -13,9 +14,13 @@ public interface GatewayBackendManager {
 
   List<ProxyBackendConfiguration> getActiveBackends(String routingGroup);
 
+  List<RoutingGroupConfiguration> getAllRoutingGroups(List<ProxyBackendConfiguration> backends);
+
   ProxyBackendConfiguration addBackend(ProxyBackendConfiguration backend);
 
   ProxyBackendConfiguration updateBackend(ProxyBackendConfiguration backend);
+
+  void deleteBackend(String backendName);
 
   void deactivateBackend(String backendName);
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaGatewayManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaGatewayManager.java
@@ -6,6 +6,7 @@ import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import com.lyft.data.gateway.ha.persistence.dao.GatewayBackend;
 
 import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -80,6 +81,28 @@ public class HaGatewayManager implements GatewayBackendManager {
     try {
       connectionManager.open();
       GatewayBackend.findFirst("name = ?", backendName).set("active", true).saveIt();
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  @Override
+  public void pauseRoutingGroup(String routingGroup) {
+    try {
+      connectionManager.open();
+      GatewayBackend.find("routing_group = ?", routingGroup)
+                    .forEach(model -> model.set("active", false).saveIt());
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  @Override
+  public void resumeRoutingGroup(String routingGroup) {
+    try {
+      connectionManager.open();
+      GatewayBackend.find("routing_group = ?", routingGroup)
+                    .forEach(model -> model.set("active", true).saveIt());
     } finally {
       connectionManager.close();
     }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaRoutingManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaRoutingManager.java
@@ -8,8 +8,9 @@ public class HaRoutingManager extends RoutingManager {
   QueryHistoryManager queryHistoryManager;
 
   public HaRoutingManager(
-      GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager) {
-    super(gatewayBackendManager);
+      GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager,
+      RoutingGroupsManager routingGroupsManager) {
+    super(gatewayBackendManager, routingGroupsManager);
     this.queryHistoryManager = queryHistoryManager;
   }
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupsManager.java
@@ -1,0 +1,185 @@
+package com.lyft.data.gateway.ha.router;
+
+import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
+import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import com.lyft.data.gateway.ha.persistence.dao.RoutingGroups;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This class contians functions to manage routing groups and get information
+ * about them from the table and ensure that data is synchronized between
+ * all the tables.
+ */
+@Slf4j
+public class RoutingGroupsManager {
+  private JdbcConnectionManager connectionManager;
+
+  public RoutingGroupsManager(JdbcConnectionManager connectionManager) {
+    this.connectionManager = connectionManager;
+  }
+
+  /**
+   * Returns a list of routing groups based on the active backends
+   * and combines information with the backends.
+   * @param backends List of backends
+   * @return List of routing groups
+   */
+  public List<RoutingGroupConfiguration> getAllRoutingGroups(
+                                         List<ProxyBackendConfiguration> backends) {
+    List<RoutingGroupConfiguration> groupsFromBackends = getAllRoutingGroupsFromBackends(backends);
+    List<RoutingGroupConfiguration> groupsFromDatabase = getAllRountingGroupsFromTable();
+
+    for (RoutingGroupConfiguration group : groupsFromDatabase) {
+      RoutingGroupConfiguration groupFromBackends = getByName(groupsFromBackends, group.getName());
+
+      if (groupFromBackends != null) {
+        group.setActiveClusters(groupFromBackends.getActiveClusters());
+        group.setNumberOfClusters(groupFromBackends.getNumberOfClusters());
+      }
+    }
+
+    return groupsFromDatabase;
+  }
+
+  /**
+   * Returns a list of routing groups contianing information from
+   * the database.
+   * @return List of routing groups from database
+   */
+  private List<RoutingGroupConfiguration> getAllRountingGroupsFromTable() {
+    try {
+      connectionManager.open();
+      List<RoutingGroups> routingGroupsList = RoutingGroups.findAll();
+      return RoutingGroups.upcast(routingGroupsList);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Returns a list of routing groups based on the active backends.
+   * @param backends List of backends
+   * @return List of routing groups
+   */
+  private List<RoutingGroupConfiguration> getAllRoutingGroupsFromBackends(
+                                         List<ProxyBackendConfiguration> backends) {
+    HashMap<String, RoutingGroupConfiguration> mapOfGroups = new HashMap<>();
+
+    backends.forEach(backend -> {
+      String routingGroup = backend.getRoutingGroup();
+      mapOfGroups.putIfAbsent(routingGroup, new RoutingGroupConfiguration(routingGroup));
+      mapOfGroups.get(routingGroup).registerBackend(backend);
+    });
+
+    return new ArrayList<RoutingGroupConfiguration>(mapOfGroups.values());
+  }
+
+  /**
+   * Adds new routing group.
+   * @param group Routing group to add
+   */
+  public void addRoutingGroup(RoutingGroupConfiguration group) {
+    try {
+      connectionManager.open();
+      RoutingGroups.create(group);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Updates a routing group and adds it if it does not yet exist.
+   * @param group Routing group to update
+   */
+  public void updateRoutingGroup(RoutingGroupConfiguration group) {
+    try {
+      connectionManager.open();
+      RoutingGroups model = RoutingGroups.findFirst("name = ?", group.getName());
+
+      if (model == null) {
+        RoutingGroups.create(group);
+      } else {
+        RoutingGroups.update(model, group);
+      }
+    } finally {
+      connectionManager.close();
+    }
+  }
+  
+  /**
+   * Deletes a routing group.
+   * @param name Name of routing group to delete
+   */
+  public void deleteRoutingGroups(String name) {
+    try {
+      connectionManager.open();
+      RoutingGroups.delete(name);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Pauses a routing group with the specified name.
+   * @param name Name of routing group
+   */
+  public void pauseRoutingGroup(String name) {
+    try {
+      connectionManager.open();
+      RoutingGroups.findFirst("name = ?", name)
+                   .set("active", false).saveIt();
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Resumes a routing group with the specified name.
+   * @param name Name of routing group
+   */
+  public void resumeRoutingGroup(String name) {
+    try {
+      connectionManager.open();
+      RoutingGroups.findFirst("name = ?", name)
+                   .set("active", true).saveIt();
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Utility function that checks if a routing group with a specified name
+   * is active (not paused).
+   * @param routingGroups List of routing groups
+   * @param name Name of routing group to be searched for
+   * @return If the routing group is active
+   */
+  public final boolean isRoutingGroupActive(List<RoutingGroupConfiguration> routingGroups, 
+      String name) {
+    return routingGroups.stream().filter(group -> group.getName().equals(name))
+              .findFirst().get().isActive();
+  }
+
+  /**
+   * Utility function that checks if a routing group with a specified name
+   * exists within the list and returns it if it exists.
+   * @param routingGroups List of routing groups
+   * @param name Name of routing group to be searched for
+   * @return If the list contains the specified name
+   */
+  public final RoutingGroupConfiguration getByName(
+      List<RoutingGroupConfiguration> routingGroups, 
+      String name) {
+    Optional<RoutingGroupConfiguration> result = routingGroups.stream()
+        .filter(group -> group.getName().equals(name)).findFirst();
+    
+    return result.isPresent() ? result.get() : null;
+  }
+}

--- a/gateway-ha/src/main/resources/assets/css/common.css
+++ b/gateway-ha/src/main/resources/assets/css/common.css
@@ -11,7 +11,7 @@
     cursor: pointer;
     padding: 14px 16px;
     font-size: 17px;
-    width: 25%;
+    width: 23%;
 }
 
 
@@ -23,6 +23,5 @@
 
 body, html {
     height: 100%;
-    margin: 0;
     font-family: Arial;
 }

--- a/gateway-ha/src/main/resources/assets/css/tableProperties.css
+++ b/gateway-ha/src/main/resources/assets/css/tableProperties.css
@@ -1,4 +1,12 @@
 /* Style for tables */
+table th {
+    text-align: left;
+}
+
+table td {
+    padding: 8px 18px;
+}
+
 table tr.activeRow, table td.activeCell {
     background-color: #90EE90;
 }

--- a/gateway-ha/src/main/resources/assets/css/tableProperties.css
+++ b/gateway-ha/src/main/resources/assets/css/tableProperties.css
@@ -1,0 +1,8 @@
+/* Style for tables */
+table tr.activeRow, table td.activeCell {
+    background-color: #90EE90;
+}
+
+table tr.disabledRow, table td.disabledCell {
+    background-color: grey;
+}

--- a/gateway-ha/src/main/resources/assets/js/changeStatus.js
+++ b/gateway-ha/src/main/resources/assets/js/changeStatus.js
@@ -1,0 +1,38 @@
+/* 
+ * Response function to reload page when response is recieved
+*/
+function reloadOnResponse() {
+    window.location.reload();
+}
+
+/* 
+ * Disables the specified cluster
+*/
+function disableCluster(clusterName) {
+    urlString = "/gateway/backend/deactivate/" + clusterName
+    $.post(urlString, reloadOnResponse)
+}
+
+/* 
+ * Activates the specified cluster
+*/
+function activateCluster(clusterName) {
+    urlString = "/gateway/backend/activate/" + clusterName
+    $.post(urlString, reloadOnResponse)
+}
+
+/* 
+ * Pauses the specific routing group
+*/
+function pauseRoutingGroup(routingGroup) {
+    urlString = "/gateway/backend/pauseRoutingGroup/" + routingGroup
+    $.post(urlString, reloadOnResponse)
+}
+
+/* 
+ * Resumes the specific routing group
+*/
+function resumeRoutingGroup(routingGroup) {
+    urlString = "/gateway/backend/resumeRoutingGroup/" + routingGroup
+    $.post(urlString, reloadOnResponse)
+}

--- a/gateway-ha/src/main/resources/assets/js/changeStatus.js
+++ b/gateway-ha/src/main/resources/assets/js/changeStatus.js
@@ -25,7 +25,7 @@ function activateCluster(clusterName) {
  * Pauses the specific routing group
 */
 function pauseRoutingGroup(routingGroup) {
-    urlString = "/gateway/backend/pauseRoutingGroup/" + routingGroup
+    urlString = "/gateway/routingGroups/pauseRoutingGroup/" + routingGroup
     $.post(urlString, reloadOnResponse)
 }
 
@@ -33,6 +33,6 @@ function pauseRoutingGroup(routingGroup) {
  * Resumes the specific routing group
 */
 function resumeRoutingGroup(routingGroup) {
-    urlString = "/gateway/backend/resumeRoutingGroup/" + routingGroup
+    urlString = "/gateway/routingGroups/resumeRoutingGroup/" + routingGroup
     $.post(urlString, reloadOnResponse)
 }

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -1,3 +1,11 @@
+CREATE DATABASE IF NOT EXISTS prestogateway;
+USE prestogateway;
+
+CREATE TABLE IF NOT EXISTS routing_groups (
+name VARCHAR(256) PRIMARY KEY,
+active BOOLEAN
+);
+
 CREATE TABLE IF NOT EXISTS gateway_backend (
 name VARCHAR(256) PRIMARY KEY,
 routing_group VARCHAR (256),
@@ -13,4 +21,8 @@ backend_url VARCHAR (256),
 user_name VARCHAR(256),
 source VARCHAR(256)
 );
+
+INSERT INTO routing_groups SELECT DISTINCT routing_group, true FROM gateway_backend;
+ALTER TABLE gateway_backend ADD CONSTRAINT routing_group_constraint FOREIGN KEY (routing_group) references routing_groups(name) ON DELETE CASCADE;
+
 CREATE INDEX query_history_created_idx ON query_history(created);

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -20,6 +20,5 @@ source VARCHAR(256)
 );
 
 INSERT INTO routing_groups SELECT DISTINCT routing_group, true FROM gateway_backend;
-ALTER TABLE gateway_backend ADD CONSTRAINT routing_group_constraint FOREIGN KEY (routing_group) references routing_groups(name) ON DELETE CASCADE;
 
 CREATE INDEX query_history_created_idx ON query_history(created);

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS routing_groups (
 name VARCHAR(256) PRIMARY KEY,
-active BOOLEAN
+active BOOLEAN DEFAULT true
 );
 
 CREATE TABLE IF NOT EXISTS gateway_backend (

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -1,6 +1,3 @@
-CREATE DATABASE IF NOT EXISTS prestogateway;
-USE prestogateway;
-
 CREATE TABLE IF NOT EXISTS routing_groups (
 name VARCHAR(256) PRIMARY KEY,
 active BOOLEAN

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -20,5 +20,6 @@ source VARCHAR(256)
 );
 
 INSERT INTO routing_groups SELECT DISTINCT routing_group, true FROM gateway_backend;
+ALTER TABLE gateway_backend ADD CONSTRAINT routing_group_constraint FOREIGN KEY (routing_group) references routing_groups(name) ON DELETE CASCADE;
 
 CREATE INDEX query_history_created_idx ON query_history(created);

--- a/gateway-ha/src/main/resources/template/gateway-view.ftl
+++ b/gateway-ha/src/main/resources/template/gateway-view.ftl
@@ -29,13 +29,21 @@
 
     <script type="application/javascript">
         $(document).ready(function () {
-            $('#clusters').DataTable(
+            $('#clusters').dataTable( {
+                "ordering": false,
+                "dom": '<"pull-left"f><"pull-right"l>tip',
+                "width": '100%',
+                "columnDefs": [ {
+                    "targets":  3,
+                    "searchable": false
+                },
                 {
-                    "ordering": false,
-                    "dom": '<"pull-left"f><"pull-right"l>tip',
-                    "width": '100%'
-                }
-            );
+                    "targets": '_all',
+                    "createdCell": function (td, cellData, rowData, row, col) {
+                        $(td).css('padding', '8px 18px')
+                    }
+                }]
+            } );
 
             $("ul.chart").hBarChart();
             document.getElementById("active_backends_tab").style.backgroundColor = "grey";

--- a/gateway-ha/src/main/resources/template/header.ftl
+++ b/gateway-ha/src/main/resources/template/header.ftl
@@ -1,9 +1,12 @@
 <h2>Presto Gateway</h2>
 <a href="/">
-    <button class="tablink" id="query_history_tab">QueryHistory</button>
+    <button class="tablink" id="query_history_tab">Query History</button>
 </a>
 <a href="/viewgateway">
     <button class="tablink" id="active_backends_tab">Active Backends</button>
+</a>
+<a href="/routingGroups">
+    <button class="tablink" id="routing_groups_tab">Routing Groups</button>
 </a>
 <a href="/entity">
     <button class="tablink" id="entity_editor_tab" style="display: none">Entity Editor</button>

--- a/gateway-ha/src/main/resources/template/header.ftl
+++ b/gateway-ha/src/main/resources/template/header.ftl
@@ -3,7 +3,7 @@
     <button class="tablink" id="query_history_tab">Query History</button>
 </a>
 <a href="/viewgateway">
-    <button class="tablink" id="active_backends_tab">Active Backends</button>
+    <button class="tablink" id="active_backends_tab">Backends</button>
 </a>
 <a href="/routingGroups">
     <button class="tablink" id="routing_groups_tab">Routing Groups</button>

--- a/gateway-ha/src/main/resources/template/query-history-view.ftl
+++ b/gateway-ha/src/main/resources/template/query-history-view.ftl
@@ -23,15 +23,22 @@
     <script src="assets/js/jquery.dataTables.min.js"></script>
     <script src="assets/js/hbar-chart.js"></script>
 
+    <link rel="stylesheet" type="text/css" href="assets/css/tableProperties.css"/>
+
     <script type="application/javascript">
         $(document).ready(function () {
-            $('#queryHistory').DataTable(
-                {
-                    "ordering": false,
-                    "dom": '<"pull-left"f><"pull-right"l>tip',
-                    "width": '100%'
-                }
-            );
+            $('#queryHistory').dataTable( {
+                "ordering": false,
+                "dom": '<"pull-left"f><"pull-right"l>tip',
+                "width": '100%',
+                "columnDefs": [ {
+                    "targets": '_all',
+                    "createdCell": function (td, cellData, rowData, row, col) {
+                        $(td).css('padding', '8px 18px')
+                    }
+                }]
+            } );
+
             $("ul.chart").hBarChart();
             document.getElementById("query_history_tab").style.backgroundColor = "grey";
         });

--- a/gateway-ha/src/main/resources/template/query-history-view.ftl
+++ b/gateway-ha/src/main/resources/template/query-history-view.ftl
@@ -1,3 +1,4 @@
+<#-- @ftlvariable name="" type="com.lyft.data.gateway.resource.GatewayViewResource$GatewayView" -->
 <#setting datetime_format = "MM/dd/yyyy hh:mm:ss a '('zzz')'">
 <html>
 <head>

--- a/gateway-ha/src/main/resources/template/routing-groups-view.ftl
+++ b/gateway-ha/src/main/resources/template/routing-groups-view.ftl
@@ -28,12 +28,22 @@
 
     <script type="application/javascript">
         $(document).ready(function () {
-            $('#routingGroups').DataTable({
-                    "ordering": false,
-                    "dom": '<"pull-left"f><"pull-right"l>tip',
-                    "width": '100%'
-                }
-            );
+            $('#routingGroups').dataTable( {
+                "ordering": false,
+                "dom": '<"pull-left"f><"pull-right"l>tip',
+                "width": '100%',
+                "columnDefs": [ {
+                    "targets":  3,
+                    "searchable": false
+                },
+                {
+                    "targets": '_all',
+                    "createdCell": function (td, cellData, rowData, row, col) {
+                        $(td).css('padding', '8px 18px')
+                    }
+                }]
+            } );
+            
             $("ul.chart").hBarChart();
             document.getElementById("routing_groups_tab").style.backgroundColor = "grey";
         });

--- a/gateway-ha/src/main/resources/template/routing-groups-view.ftl
+++ b/gateway-ha/src/main/resources/template/routing-groups-view.ftl
@@ -64,7 +64,7 @@
             <tr>
                 <th>Group Name</th>
                 <th>Active Clusters</th>
-                <th>Group Size</th>
+                <th>Number Of Clusters</th>
                 <th>Change Status</th>
                 <th>Status</th>
             </tr>
@@ -75,7 +75,7 @@
                 <tr>
                     <td> ${routingGroup.name}</td>
                     <td> ${routingGroup.activeClusters}</td>
-                    <td> ${routingGroup.groupSize}</td>
+                    <td> ${routingGroup.numberOfClusters}</td>
 
                     <#if routingGroup.active == true>
                         <td><button onclick = 'pauseRoutingGroup("${routingGroup.name}")'>Pause Routing Group</button></td>

--- a/gateway-ha/src/main/resources/template/routing-groups-view.ftl
+++ b/gateway-ha/src/main/resources/template/routing-groups-view.ftl
@@ -1,6 +1,6 @@
 <#-- @ftlvariable name="" type="com.lyft.data.gateway.resource.GatewayViewResource$GatewayView" -->
 <#setting datetime_format = "MM/dd/yyyy hh:mm:ss a '('zzz')'">
-    <html>
+<html>
 <head>
     <meta charset="UTF-8"/>
     <style>
@@ -16,7 +16,6 @@
             width: 500px
         }
     </style>
-
     <link rel="stylesheet" type="text/css" href="assets/css/common.css"/>
     <link rel="stylesheet" type="text/css" href="assets/css/jquery.dataTables.min.css"/>
 
@@ -29,17 +28,16 @@
 
     <script type="application/javascript">
         $(document).ready(function () {
-            $('#clusters').DataTable(
-                {
+            $('#routingGroups').DataTable({
                     "ordering": false,
                     "dom": '<"pull-left"f><"pull-right"l>tip',
                     "width": '100%'
                 }
             );
-
             $("ul.chart").hBarChart();
-            document.getElementById("active_backends_tab").style.backgroundColor = "grey";
+            document.getElementById("routing_groups_tab").style.backgroundColor = "grey";
         });
+
     </script>
 </head>
 <body>
@@ -50,31 +48,31 @@
 </div>
 
 <div>
-    <h3>All backends:</h3>
-    <table id="clusters" class="display">
+    <h3>Routing Groups:<h3>
+    <table id="routingGroups" class="display">
         <thead>
             <tr>
-                <th>ClusterName</th>
-                <th>URL</th>
-                <th>RoutingGroup</th>
+                <th>Group Name</th>
+                <th>Active Clusters</th>
+                <th>Group Size</th>
                 <th>Change Status</th>
                 <th>Status</th>
             </tr>
         </thead>
 
         <tbody>
-            <#list backendConfigurations as bc>
+            <#list routingGroupConfigurations as routingGroup>
                 <tr>
-                    <td>  ${bc.name}</td>
-                    <td><a href="${bc.proxyTo}/ui" target="_blank">${bc.proxyTo}</a></td>
-                    <td> ${bc.routingGroup}</td>
+                    <td> ${routingGroup.name}</td>
+                    <td> ${routingGroup.activeClusters}</td>
+                    <td> ${routingGroup.groupSize}</td>
 
-                    <#if bc.active == true>
-                        <td><button onclick = 'disableCluster("${bc.name}")'>Disable Cluster</button></td>
+                    <#if routingGroup.active == true>
+                        <td><button onclick = 'pauseRoutingGroup("${routingGroup.name}")'>Pause Routing Group</button></td>
                         <td class = "activeCell">active</td>
                     <#else>
-                        <td><button onclick = 'activateCluster("${bc.name}")'>Activate Cluster</button></td>
-                        <td class = "disabledCell">disabled</td>
+                        <td><button onclick = 'resumeRoutingGroup("${routingGroup.name}")'>Resume Routing Group</button></td>
+                        <td class = "disabledCell">paused</td>
                     </#if>
                 </tr>
             </#list>

--- a/gateway-ha/src/migrations/gateway-ha.sql
+++ b/gateway-ha/src/migrations/gateway-ha.sql
@@ -1,4 +1,10 @@
-CREATE DATABASE prestogateway;
+CREATE DATABASE IF NOT EXISTS prestogateway;
+USE prestogateway;
+
+CREATE TABLE IF NOT EXISTS routing_groups (
+name VARCHAR(256) PRIMARY KEY,
+active BIT(1)
+);
 
 CREATE TABLE IF NOT EXISTS gateway_backend (
 name VARCHAR(256) PRIMARY KEY,
@@ -15,4 +21,6 @@ backend_url VARCHAR (256),
 user_name VARCHAR(256),
 source VARCHAR(256)
 );
+
+ALTER TABLE gateway_backend ADD CONSTRAINT routing_group_constraint FOREIGN KEY (routing_group) references routing_groups(name) ON DELETE CASCADE;
 CREATE INDEX query_history_created_idx ON query_history(created);

--- a/gateway-ha/src/migrations/gateway-ha.sql
+++ b/gateway-ha/src/migrations/gateway-ha.sql
@@ -3,7 +3,7 @@ USE prestogateway;
 
 CREATE TABLE IF NOT EXISTS routing_groups (
 name VARCHAR(256) PRIMARY KEY,
-active BOOLEAN
+active BOOLEAN DEFAULT true
 );
 
 CREATE TABLE IF NOT EXISTS gateway_backend (

--- a/gateway-ha/src/migrations/gateway-ha.sql
+++ b/gateway-ha/src/migrations/gateway-ha.sql
@@ -3,7 +3,7 @@ USE prestogateway;
 
 CREATE TABLE IF NOT EXISTS routing_groups (
 name VARCHAR(256) PRIMARY KEY,
-active BIT(1)
+active BOOLEAN
 );
 
 CREATE TABLE IF NOT EXISTS gateway_backend (
@@ -22,5 +22,7 @@ user_name VARCHAR(256),
 source VARCHAR(256)
 );
 
+INSERT INTO routing_groups SELECT DISTINCT routing_group, true FROM gateway_backend;
 ALTER TABLE gateway_backend ADD CONSTRAINT routing_group_constraint FOREIGN KEY (routing_group) references routing_groups(name) ON DELETE CASCADE;
+
 CREATE INDEX query_history_created_idx ON query_history(created);

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/HaGatewayTestUtils.java
@@ -102,7 +102,7 @@ public class HaGatewayTestUtils {
   public static void setUpBackend(
       String name, String proxyTo, boolean active, String routingGroup, int routerPort)
       throws Exception {
-    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration(routingGroup));
+    routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration(routingGroup));
     RequestBody requestBody =
         RequestBody.create(
             MediaType.parse("application/json; charset=utf-8"),

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/HaGatewayTestUtils.java
@@ -3,7 +3,10 @@ package com.lyft.data.gateway.ha;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import com.lyft.data.gateway.ha.router.RoutingGroupsManager;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -27,6 +30,7 @@ import org.testng.Assert;
 public class HaGatewayTestUtils {
   private static final OkHttpClient httpClient = new OkHttpClient();
   private static final Random RANDOM = new Random();
+  private static RoutingGroupsManager routingGroupsManager;
 
   @Data
   @NoArgsConstructor
@@ -40,6 +44,7 @@ public class HaGatewayTestUtils {
     String jdbcUrl = "jdbc:h2:" + testConfig.getH2DbFilePath();
     DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
     JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
+    routingGroupsManager = new RoutingGroupsManager(connectionManager);
     connectionManager.open();
     Base.exec(HaGatewayTestUtils.getResourceFileContent("gateway-ha-persistence.sql"));
     connectionManager.close();
@@ -97,6 +102,7 @@ public class HaGatewayTestUtils {
   public static void setUpBackend(
       String name, String proxyTo, boolean active, String routingGroup, int routerPort)
       throws Exception {
+    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration(routingGroup));
     RequestBody requestBody =
         RequestBody.create(
             MediaType.parse("application/json; charset=utf-8"),

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestHaGatewayManager.java
@@ -3,6 +3,7 @@ package com.lyft.data.gateway.ha.router;
 import com.lyft.data.gateway.ha.HaGatewayTestUtils;
 import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import java.io.File;
 import java.util.List;
@@ -15,6 +16,7 @@ import org.testng.annotations.Test;
 @Test
 public class TestHaGatewayManager {
   private HaGatewayManager haGatewayManager;
+  private RoutingGroupsManager routingGroupsManager;
 
   @BeforeClass(alwaysRun = true)
   public void setUp() {
@@ -27,9 +29,12 @@ public class TestHaGatewayManager {
     DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
     JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
     haGatewayManager = new HaGatewayManager(connectionManager);
+    routingGroupsManager = new RoutingGroupsManager(connectionManager);
   }
 
   public void testAddBackend() {
+    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration("adhoc"));
+    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration("etl"));
     ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
     backend.setActive(true);
     backend.setRoutingGroup("adhoc");

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestHaGatewayManager.java
@@ -30,11 +30,14 @@ public class TestHaGatewayManager {
     JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
     haGatewayManager = new HaGatewayManager(connectionManager);
     routingGroupsManager = new RoutingGroupsManager(connectionManager);
+    routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration("adhoc"));
+    routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration("etl"));
   }
 
+  @Test
   public void testAddBackend() {
-    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration("adhoc"));
-    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration("etl"));
+    routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration("adhoc"));
+    routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration("etl"));
     ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
     backend.setActive(true);
     backend.setRoutingGroup("adhoc");

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -25,6 +25,7 @@ public class TestPrestoQueueLengthRoutingTable {
   PrestoQueueLengthRoutingTable routingTable;
   GatewayBackendManager backendManager;
   QueryHistoryManager historyManager;
+  RoutingGroupsManager routingGroupsManager;
   String[] mockRoutingGroups = {"adhoc", "scheduled"};
   String mockRoutingGroup = "adhoc";
   Map<String, Map<String, Integer>> clusterQueueMap;
@@ -45,7 +46,9 @@ public class TestPrestoQueueLengthRoutingTable {
     backendManager = new HaGatewayManager(connectionManager);
     historyManager = new HaQueryHistoryManager(gatewayConf, connectionManager) {
     };
-    routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager);
+    routingGroupsManager = new RoutingGroupsManager(connectionManager);
+    routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager, 
+                                                     routingGroupsManager);
 
     for (String grp : mockRoutingGroups) {
       addMockBackends(grp, NUM_BACKENDS, 0);

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -52,7 +52,7 @@ public class TestPrestoQueueLengthRoutingTable {
                                                      routingGroupsManager);
 
     for (String grp : mockRoutingGroups) {
-      routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration(grp));
+      routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration(grp));
       addMockBackends(grp, NUM_BACKENDS, 0);
     }
   }
@@ -115,7 +115,7 @@ public class TestPrestoQueueLengthRoutingTable {
 
   private void registerBackEnds(String groupName, int numBackends,
                                 int queueLengthDistributiveFactor) {
-    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration(groupName));
+    routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration(groupName));
     int mockQueueLength = 0;
     String backend;
 

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -7,6 +7,7 @@ import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
 import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
 import com.lyft.data.gateway.ha.config.RequestRouterConfiguration;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import java.io.File;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ public class TestPrestoQueueLengthRoutingTable {
                                                      routingGroupsManager);
 
     for (String grp : mockRoutingGroups) {
+      routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration(grp));
       addMockBackends(grp, NUM_BACKENDS, 0);
     }
   }
@@ -113,6 +115,7 @@ public class TestPrestoQueueLengthRoutingTable {
 
   private void registerBackEnds(String groupName, int numBackends,
                                 int queueLengthDistributiveFactor) {
+    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration(groupName));
     int mockQueueLength = 0;
     String backend;
 

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestQueryHistoryManager.java
@@ -34,6 +34,7 @@ public class TestQueryHistoryManager {
     queryHistoryManager = new HaQueryHistoryManager(gatewayConf, connectionManager) {};
   }
 
+  @Test
   public void testSubmitAndFetchQueryHistory() {
     List<QueryHistoryManager.QueryDetail> queryDetails = queryHistoryManager.fetchQueryHistory();
     Assert.assertEquals(queryDetails.size(), 0);

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupsManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupsManager.java
@@ -1,16 +1,17 @@
 package com.lyft.data.gateway.ha.router;
 
-import java.io.File;
-import java.util.List;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
 import com.lyft.data.gateway.ha.HaGatewayTestUtils;
 import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
 import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+
+import java.io.File;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+
+import org.testng.annotations.Test;
 
 @Test
 public class TestRoutingGroupsManager {
@@ -20,7 +21,7 @@ public class TestRoutingGroupsManager {
   @BeforeClass(alwaysRun = true)
   public void setup() {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
-    File tempH2DbDir = new File(baseDir, "h2db-" + System.currentTimeMillis());
+    File tempH2DbDir = new File(baseDir, "h2db-rg-" + System.currentTimeMillis());
     tempH2DbDir.deleteOnExit();
 
     HaGatewayTestUtils.seedRequiredData(
@@ -38,13 +39,14 @@ public class TestRoutingGroupsManager {
     List<ProxyBackendConfiguration> backends = haGatewayManager.getAllBackends();
     List<RoutingGroupConfiguration> groups = routingGroupsManager.getAllRoutingGroups(backends);
 
-    Assert.assertEquals(groups.size(), 0);
     for (int i = 0; i < 10; i++) {
-      RoutingGroupConfiguration rg = new RoutingGroupConfiguration(i+ "");
+      RoutingGroupConfiguration rg = new RoutingGroupConfiguration(Integer.toString(i));
       routingGroupsManager.addRoutingGroup(rg);
     }
 
     groups = routingGroupsManager.getAllRoutingGroups(backends);
-    Assert.assertEquals(groups.size(), 10);
+    for (int i = 0; i < 10; i++) {
+      Assert.assertNotNull(routingGroupsManager.getByName(groups, Integer.toString(i)));
+    }
   }
 }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupsManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupsManager.java
@@ -1,0 +1,50 @@
+package com.lyft.data.gateway.ha.router;
+
+import java.io.File;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.lyft.data.gateway.ha.HaGatewayTestUtils;
+import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
+import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+import com.lyft.data.gateway.ha.config.RoutingGroupConfiguration;
+import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+
+@Test
+public class TestRoutingGroupsManager {
+  private RoutingGroupsManager routingGroupsManager;
+  private HaGatewayManager haGatewayManager;
+
+  @BeforeClass(alwaysRun = true)
+  public void setup() {
+    File baseDir = new File(System.getProperty("java.io.tmpdir"));
+    File tempH2DbDir = new File(baseDir, "h2db-" + System.currentTimeMillis());
+    tempH2DbDir.deleteOnExit();
+
+    HaGatewayTestUtils.seedRequiredData(
+        new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
+    String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
+    DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
+    JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
+
+    haGatewayManager = new HaGatewayManager(connectionManager);
+    routingGroupsManager = new RoutingGroupsManager(connectionManager);
+  }
+
+  @Test
+  public void testAddingRoutingGroup() {
+    List<ProxyBackendConfiguration> backends = haGatewayManager.getAllBackends();
+    List<RoutingGroupConfiguration> groups = routingGroupsManager.getAllRoutingGroups(backends);
+
+    Assert.assertEquals(groups.size(), 0);
+    for (int i = 0; i < 10; i++) {
+      RoutingGroupConfiguration rg = new RoutingGroupConfiguration(i+ "");
+      routingGroupsManager.addRoutingGroup(rg);
+    }
+
+    groups = routingGroupsManager.getAllRoutingGroups(backends);
+    Assert.assertEquals(groups.size(), 10);
+  }
+}


### PR DESCRIPTION
- [x] Include relevant Jira ticket ID(s) in the PR title

### Why?
 - Adding functionality to view the state of routing groups from the presto-gateway webpage
 - Also adding functionality to activate and deactivate specific clusters and routing groups directly from the presto-gateway webpage

### How?
 - Added a new page on the presto-gateway website (new endpoint that returns HTML info) that corresponds to viewing routing groups
 - Added buttons and functionality to interact with endpoints to activate/deactivate clusters and pause/resume routing groups
 - Added a new endpoint to the API to request to see the routing group information

### Testing Evidence
 - Verified UI/backend synchronization
 - Tested all endpoints
 - Verified SQL routing group rule compliance
 - Applied migrations file to pre-existing database to test validity
 - Verified that buttons to pause/resume and activate/deactivate a cluster were functional

**Updated Backends Page:**
![image](https://user-images.githubusercontent.com/107955840/181811510-1037278b-4039-4728-b048-b668827a4426.png)

**Updated Routing Groups Page:**
![image](https://user-images.githubusercontent.com/107955840/181811574-74d2c902-c4a7-42c2-a93e-c1a59c64d611.png)


### Deployment Steps
 - Run migrations file on database
 - Register required routing groups to routingGroups table

### Deployment Verification
 - Check if the routing groups page is active (`https://presto-gateway.prod1.6si.com/routingGroups`)