### PR TITLE
INFRA 4164 Add option to disable notifier

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
@@ -42,6 +42,4 @@ public class HealthChecker implements PrestoClusterStatsObserver {
     notifier.sendNotification(String.format("%s - Number of workers",
         clusterStats.getClusterId()), clusterStats.toString());
   }
-
-
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
@@ -35,7 +35,12 @@ public class ClusterStateListenerModule extends AppModule<HaGatewayConfiguration
   public List<PrestoClusterStatsObserver> getClusterStatsObservers(RoutingManager routingManager) {
     observers = new ArrayList<>();
     NotifierConfiguration notifierConfiguration = getConfiguration().getNotifier();
-    observers.add(new HealthChecker(new EmailNotifier(notifierConfiguration)));
+
+    // Add email notifier if enabled
+    if (notifierConfiguration != null) {
+      observers.add(new HealthChecker(new EmailNotifier(notifierConfiguration)));
+    }
+
     observers.add(new PrestoQueueLengthChecker((PrestoQueueLengthRoutingTable)routingManager));
     return observers;
   }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/notifier/EmailNotifier.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/notifier/EmailNotifier.java
@@ -45,42 +45,44 @@ public class EmailNotifier implements Notifier {
   @Override
   public void sendNotification(
       String from, List<String> recipients, String subject, String content) {
-    if (recipients.size() > 0) {
-      Session session = Session.getDefaultInstance(props);
-      MimeMessage message = new MimeMessage(session);
-      try {
-        message.setFrom(new InternetAddress(from));
+    if (notifierConfiguration != null) {
+      if (recipients.size() > 0) {
+        Session session = Session.getDefaultInstance(props);
+        MimeMessage message = new MimeMessage(session);
+        try {
+          message.setFrom(new InternetAddress(from));
 
-        // To get the array of addresses
-        recipients.forEach(
-            r -> {
-              try {
-                message.addRecipient(Message.RecipientType.TO, new InternetAddress(r));
-              } catch (Exception e) {
-                log.error("Recipient email [" + e + "] could not be added", e);
-              }
-            });
-        message.setSubject(subject);
-        message.setText(content);
-        try (Transport transport = session.getTransport("smtp")) {
-          if (notifierConfiguration.isSmtpAuthEnabled()) {
-            transport.connect(
-                notifierConfiguration.getSmtpHost(),
-                notifierConfiguration.getSmtpUser(),
-                notifierConfiguration.getSmtpPassword());
-          } else {
-            transport.connect();
+          // To get the array of addresses
+          recipients.forEach(
+              r -> {
+                try {
+                  message.addRecipient(Message.RecipientType.TO, new InternetAddress(r));
+                } catch (Exception e) {
+                  log.error("Recipient email [" + e + "] could not be added", e);
+                }
+              });
+          message.setSubject(subject);
+          message.setText(content);
+          try (Transport transport = session.getTransport("smtp")) {
+            if (notifierConfiguration.isSmtpAuthEnabled()) {
+              transport.connect(
+                  notifierConfiguration.getSmtpHost(),
+                  notifierConfiguration.getSmtpUser(),
+                  notifierConfiguration.getSmtpPassword());
+            } else {
+              transport.connect();
+            }
+            transport.sendMessage(message, message.getAllRecipients());
+          } catch (Exception e) {
+            log.error("Error creating email transport client", e);
           }
-          transport.sendMessage(message, message.getAllRecipients());
+          log.debug("Sent message [{}] successfully.", content);
         } catch (Exception e) {
-          log.error("Error creating email transport client", e);
+          log.error("Error sending alert", e);
         }
-        log.debug("Sent message [{}] successfully.", content);
-      } catch (Exception e) {
-        log.error("Error sending alert", e);
+      } else {
+        log.warn("No recipients configured to send app notification [{}]", content);
       }
-    } else {
-      log.warn("No recipients configured to send app notification [{}]", content);
     }
   }
 }


### PR DESCRIPTION
- [x] Include relevant Jira ticket ID(s) in the PR title

## Why
 - Adds an option to disable the email notifier within presto-gateway
 - Since we do not currently use the email notifier, it creates large amount of useless overhead and clogs up the logs with errors
## How
 - If no email notifier is wanted, then the notifier portion of the configuration file can just be omitted
 ## Testing Evidence
 - Server builds and runs fine
 - Email notifier is never called
 - No notification is sent if notification is omitted from the configuration)
 - **Dev Deployment Log** (No errors caused by notifier)
![image](https://user-images.githubusercontent.com/107955840/181348946-6775db4a-9b25-4cb2-880d-56f65d30032f.png)
 - **Dev Deployment Config File** (Notifier removed)
![image](https://user-images.githubusercontent.com/107955840/181349272-f31f4978-b256-46a0-b5c8-266327e03b95.png)
 - **Dev Deployment Log After Notifier Addition** (Still produces the same errors it used to)
![image](https://user-images.githubusercontent.com/107955840/181595397-a1af4052-2d4c-407a-a6c9-a8967061fd19.png)

  ## Deployment Steps
 - Update code running in production
 ## Deployment Verification
 - N/A