### PR TITLE
INFRA-4168 Prevent routing failure on cluster error

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -23,6 +23,11 @@ import javax.ws.rs.HttpMethod;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
 
+/**
+ * This class creates a thread that runs every 5 seconds
+ * and queries all backends and updates the routing
+ * table based on that information.
+ */
 @Slf4j
 public class ActiveClusterMonitor implements Managed {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -47,11 +52,13 @@ public class ActiveClusterMonitor implements Managed {
         () -> {
           while (monitorActive) {
             try {
-              List<ProxyBackendConfiguration> activeClusters =
+              List<ProxyBackendConfiguration> activeClusters = 
                   gatewayBackendManager.getAllActiveBackends();
+                  
               List<Future<ClusterStats>> futures = new ArrayList<>();
+
               for (ProxyBackendConfiguration backend : activeClusters) {
-                Future<ClusterStats> call =
+                Future<ClusterStats> call = 
                     executorService.submit(() -> getPrestoClusterStats(backend));
                 futures.add(call);
               }
@@ -70,6 +77,7 @@ public class ActiveClusterMonitor implements Managed {
             } catch (Exception e) {
               log.error("Error performing backend monitor tasks", e);
             }
+
             try {
               Thread.sleep(MONITOR_TASK_DELAY_SECS * 1000);
             } catch (Exception e) {
@@ -79,58 +87,69 @@ public class ActiveClusterMonitor implements Managed {
         });
   }
 
+  /**
+   * Sends an HTTP request to a backend to get information about
+   * the current status of the backend and returns it.
+   * 
+   * @param backend Backend to get information about
+   * @return A {@link ClusterStats} variable with information about the backend
+   */
   private ClusterStats getPrestoClusterStats(ProxyBackendConfiguration backend) {
     ClusterStats clusterStats = new ClusterStats();
     clusterStats.setClusterId(backend.getName());
+    clusterStats.setHealthy(false);
+
     // The V1_NODE_PATH is used in 331 while V1_CLUSTER_PATH is used in 318
     // TODO: Remove V1_CLUSTER_PATH once we're upgraded all clusters.
-    String[] possiblePaths = new String[] {UI_API_STATS_PATH, "/v1/cluster"};
-    String dynpath = ""; //Path Based on Presto and Trino cluster
-    for (String path : possiblePaths) {
-      if (backend.getProxyTo().contains("trino") || backend.getProxyTo().contains("dashboard")) {
-        dynpath = UI_API_STATS_PATH;
+
+    String dynpath = ""; // Path Based on Presto and Trino cluster
+
+    if (backend.getProxyTo().contains("trino") || backend.getProxyTo().contains("dashboard")) {
+      dynpath = UI_API_STATS_PATH;
+    } else {
+      dynpath = "/v1/cluster";
+    }
+
+    String target = backend.getProxyTo() + dynpath;
+    HttpURLConnection conn = null;
+    try {
+      URL url = new URL(target);
+      conn = (HttpURLConnection) url.openConnection();
+      conn.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(BACKEND_CONNECT_TIMEOUT_SECONDS));
+      conn.setReadTimeout((int) TimeUnit.SECONDS.toMillis(BACKEND_CONNECT_TIMEOUT_SECONDS));
+      conn.setRequestMethod(HttpMethod.GET);
+      conn.connect();
+      int responseCode = conn.getResponseCode();
+      if (responseCode == HttpStatus.SC_OK) {
+        clusterStats.setHealthy(true);
+        BufferedReader reader = 
+            new BufferedReader(new InputStreamReader((InputStream) conn.getContent()));
+            
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          sb.append(line + "\n");
+        }
+        HashMap<String, Object> result = OBJECT_MAPPER.readValue(sb.toString(), HashMap.class);
+        clusterStats.setNumWorkerNodes((int) result.get("activeWorkers"));
+        clusterStats.setQueuedQueryCount((int) result.get("queuedQueries"));
+        clusterStats.setRunningQueryCount((int) result.get("runningQueries"));
+        clusterStats.setBlockedQueryCount((int) result.get("blockedQueries"));
+        clusterStats.setProxyTo(backend.getProxyTo());
+        clusterStats.setRoutingGroup(backend.getRoutingGroup());
+        log.info("Host: {}, Cluster_stat: {}", System.getenv("HOSTNAME"), clusterStats);
       } else {
-        dynpath = "/v1/cluster";
+        log.warn("Received non 200 response, response code: {}", responseCode);
       }
-      String target = backend.getProxyTo() + dynpath;
-      HttpURLConnection conn = null;
-      try {
-        URL url = new URL(target);
-        conn = (HttpURLConnection) url.openConnection();
-        conn.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(BACKEND_CONNECT_TIMEOUT_SECONDS));
-        conn.setReadTimeout((int) TimeUnit.SECONDS.toMillis(BACKEND_CONNECT_TIMEOUT_SECONDS));
-        conn.setRequestMethod(HttpMethod.GET);
-        conn.connect();
-        int responseCode = conn.getResponseCode();
-        if (responseCode == HttpStatus.SC_OK) {
-          clusterStats.setHealthy(true);
-          BufferedReader reader =
-              new BufferedReader(new InputStreamReader((InputStream) conn.getContent()));
-          StringBuilder sb = new StringBuilder();
-          String line;
-          while ((line = reader.readLine()) != null) {
-            sb.append(line + "\n");
-          }
-          HashMap<String, Object> result = OBJECT_MAPPER.readValue(sb.toString(), HashMap.class);
-          clusterStats.setNumWorkerNodes((int) result.get("activeWorkers"));
-          clusterStats.setQueuedQueryCount((int) result.get("queuedQueries"));
-          clusterStats.setRunningQueryCount((int) result.get("runningQueries"));
-          clusterStats.setBlockedQueryCount((int) result.get("blockedQueries"));
-          clusterStats.setProxyTo(backend.getProxyTo());
-          clusterStats.setRoutingGroup(backend.getRoutingGroup());
-          log.info("Host: {}, Cluster_stat: {}", System.getenv("HOSTNAME"), clusterStats);
-          break;
-        } else {
-          log.warn("Received non 200 response, response code: {}", responseCode);
-        }
-      } catch (Exception e) {
-        log.error("Error fetching cluster stats from [{}]", target, e);
-      } finally {
-        if (conn != null) {
-          conn.disconnect();
-        }
+    } catch (Exception e) {
+      clusterStats.setHealthy(false);
+      log.error("Error fetching cluster stats from [{}]", target, e);
+    } finally {
+      if (conn != null) {
+        conn.disconnect();
       }
     }
+
     return clusterStats;
   }
 
@@ -142,5 +161,4 @@ public class ActiveClusterMonitor implements Managed {
     this.executorService.shutdown();
     this.singleTaskExecutor.shutdown();
   }
-
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -139,7 +139,8 @@ public class ActiveClusterMonitor implements Managed {
         clusterStats.setRoutingGroup(backend.getRoutingGroup());
         log.info("Host: {}, Cluster_stat: {}", System.getenv("HOSTNAME"), clusterStats);
       } else {
-        log.warn("Received non 200 response, response code: {}", responseCode);
+        log.error("Received non 200 response, response code: " 
+            + "{} when fetching cluster stats from [{}]", responseCode, target);
       }
     } catch (Exception e) {
       clusterStats.setHealthy(false);

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
@@ -6,7 +6,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Updates the QueueLength Based Routing Manager {@link PrestoQueueLengthRoutingTable} with
+ * Updates the QueueLength Based Routing Manager
+ * {@link PrestoQueueLengthRoutingTable} with
  * updated queue lengths of active clusters.
  */
 public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
@@ -17,21 +18,24 @@ public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
     this.routingManager = routingManager;
   }
 
+  /**
+   * Creates a mapping of routing group to clusterID and query count
+   * in order to update the routing table.
+   * 
+   * @param stats List of cluster stats
+   */
   @Override
   public void observe(List<ClusterStats> stats) {
-    Map<String, Map<String, Integer>> clusterQueueMap = new HashMap<String, Map<String, Integer>>();
+    Map<String, Map<String, Integer>> clusterQueueMap = 
+        new HashMap<String, Map<String, Integer>>();
 
     for (ClusterStats stat : stats) {
-      if (!clusterQueueMap.containsKey(stat.getRoutingGroup())) {
-        clusterQueueMap.put(stat.getRoutingGroup(), new HashMap<String, Integer>() {
-              {
-                put(stat.getClusterId(), stat.getQueuedQueryCount());
-              }
-            }
-        );
-      } else {
-        clusterQueueMap.get(stat.getRoutingGroup()).put(stat.getClusterId(),
-            stat.getQueuedQueryCount());
+      // Only add healthy clusters to be routed to that have active workers
+      if (stat.isHealthy() && stat.getNumWorkerNodes() > 0) {
+        clusterQueueMap.putIfAbsent(stat.getRoutingGroup(), new HashMap<String, Integer>());
+
+        clusterQueueMap.get(stat.getRoutingGroup())
+                       .put(stat.getClusterId(), stat.getQueuedQueryCount());
       }
     }
 


### PR DESCRIPTION
- [x] Include relevant Jira ticket ID(s) in the PR title

## Why
 - Prevents a complete routing failure when a cluster is down
## How
 - Checks to see if a cluster is healthy and active before attempting to perform routing on it
 - Also prevents routing to a cluster that has no active workers
## Testing Evidence
 - Routing continued being recomputed even with incorrect cluster in backends

 With the following cluster stats: 
![image](https://user-images.githubusercontent.com/107955840/181393281-638a4267-1117-4e54-ace0-58b7a78a1441.png)

The routing produced is (Omits adhoctrino as it has 0 active workers): 
![image](https://user-images.githubusercontent.com/107955840/181393332-06820ae7-09b9-4d12-9265-a411af3331bb.png)

With these cluster stats (Changed main1 backend to example.com to represent cluster that is down):
![image](https://user-images.githubusercontent.com/107955840/181600849-62b0e4f2-8c45-49ca-975d-90f9599ec641.png)

The routing produced is (Omits adhoctrino as it has 0 active workers and main1 because its offline):
![image](https://user-images.githubusercontent.com/107955840/181601050-b533af39-0218-43dc-8e18-4e440d494bd5.png)

## Deployment Steps
 - N/A
## Deployment Verification
 - Routing should not fail when improper cluster exists