### PR TITLE
INFRA 4463 Prevent query storage on incomplete query

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -233,6 +233,10 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
           if (!Strings.isNullOrEmpty(queryDetail.getQueryId())) {
             routingManager.setBackendForQueryId(
                 queryDetail.getQueryId(), queryDetail.getBackendUrl());
+
+            // Saving history at gateway.
+            queryHistoryManager.submitQueryDetail(queryDetail);
+            
             log.debug(
                 "QueryId [{}] mapped with proxy [{}]",
                 queryDetail.getQueryId(),
@@ -246,8 +250,6 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
               output,
               response.getStatus());
         }
-        // Saving history at gateway.
-        queryHistoryManager.submitQueryDetail(queryDetail);
       } else {
         log.debug("SKIPPING For {}", requestPath);
       }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -52,7 +52,6 @@ public class TestPrestoQueueLengthRoutingTable {
                                                      routingGroupsManager);
 
     for (String grp : mockRoutingGroups) {
-      routingGroupsManager.updateRoutingGroup(new RoutingGroupConfiguration(grp));
       addMockBackends(grp, NUM_BACKENDS, 0);
     }
   }
@@ -67,6 +66,7 @@ public class TestPrestoQueueLengthRoutingTable {
   private void addMockBackends(String groupName, int numBackends,
                                int queueLengthDistributiveFactor) {
     String backend = null;
+    routingGroupsManager.addRoutingGroup(new RoutingGroupConfiguration(groupName));
 
     for (int i = 0; i < numBackends; i++) {
       backend = groupName + i;


### PR DESCRIPTION
- [x] Include relevant Jira ticket ID(s) in the PR title

### Why?
 - Reduce the number of unnecessary errors produced by Presto Gateway

### How?
 - Only saving information in the query history table when it represents a complete request

### Testing Evidence
 - Successful Jenkins build
 - Locally passes unit tests
 - Query history saving works properly
 - Logs do not contains SQL error on incomplete query

### Deployment Steps
 - N/A

### Deployment Verification
 - N/A