### PR TITLE
INFRA-4746 Prevent port repetition

### DIFF
--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHa.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHa.java
@@ -19,10 +19,10 @@ public class TestGatewayHa {
 
   private final OkHttpClient httpClient = new OkHttpClient();
 
-  final int routerPort = 20000 + (int) (Math.random() * 1000);
-  final int backendPort = 21000 + (int) (Math.random() * 1000);
-  final int backend1Port = 21000 + (int) (Math.random() * 1000);
-  final int backend2Port = 21000 + (int) (Math.random() * 1000);
+  final int routerPort = 20000 + (int) (Math.random() * 900);
+  final int backendPort = routerPort + 1;
+  final int backend1Port = routerPort + 2;
+  final int backend2Port = routerPort + 3;
 
   private WireMockServer backend =
       new WireMockServer(WireMockConfiguration.options().port(backendPort));


### PR DESCRIPTION
- [x] Include relevant Jira ticket ID(s) in the PR title

### Why?
 - Within tests, it is possible for ports to be repeated, causing for builds to randomly fail

### How?
 - By making the ports dependent upon each other

### Testing Evidence
 - Build completes properly and tests pass

### Deployment Steps
 - N/A

### Deployment Verification
 - N/A